### PR TITLE
Document AI/Claude Code layer and templates in top-level README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ This repository defines engineering standards for building software. The standar
 
 - **[process/](./process/)** - Software process and SDLC standards (workflows, git, planning, documentation)
 - **[code/](./code/)** - Language and stack-specific code quality standards ([Python](./code/python-standards.md), [Database](./code/database-standards.md), [Web Application](./code/web-application-standards.md))
-- **[templates/](./templates/)** - Project templates with pre-configured tooling (future)
 - **[ai/](./ai/)** - AI assistant configuration and Claude Code integration ([details](./ai/claude-code/README.md))
 - **[templates/](./templates/)** - Project starter kit with Claude Code configuration (`.claude/` directory template)
 - **[agent-transcripts/](./agent-transcripts/)** - Historical development logs
@@ -112,7 +111,7 @@ Defines how Claude Code actively enforces the standards in `process/` and `code/
 Starter kit for adopting these standards in new projects with Claude Code:
 
 1. Copy `templates/.claude/` into your project root as `.claude/`
-2. Copy `templates/CLAUDE.md` to your project root
+2. Copy `templates/CLAUDE.md` to your project root and fill in the placeholder sections
 3. Customize skills, agents, hooks, and settings for your project's architecture
 
 The template includes pre-configured skills that reference the canonical standards via URL, so they stay in sync without duplication.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ This repository defines engineering standards for building software. The standar
 - **[process/](./process/)** - Software process and SDLC standards (workflows, git, planning, documentation)
 - **[code/](./code/)** - Language and stack-specific code quality standards ([Python](./code/python-standards.md), [Database](./code/database-standards.md), [Web Application](./code/web-application-standards.md))
 - **[templates/](./templates/)** - Project templates with pre-configured tooling (future)
-- **[ai/](./ai/)** - AI assistant content and reference documentation
+- **[ai/](./ai/)** - AI assistant configuration and Claude Code integration ([details](./ai/claude-code/README.md))
+- **[templates/](./templates/)** - Project starter kit with Claude Code configuration (`.claude/` directory template)
 - **[agent-transcripts/](./agent-transcripts/)** - Historical development logs
 
 ## Process Standards
@@ -92,6 +93,29 @@ Conversation logs documenting the development and evolution of these standards t
 - Questions addressed and resolved
 
 These transcripts provide historical context and reasoning behind the standards, useful for understanding why certain approaches were chosen and how to adapt them appropriately.
+
+## AI / Claude Code Integration
+
+### [Claude Code Layer Model](./ai/claude-code/README.md)
+
+Defines how Claude Code actively enforces the standards in `process/` and `code/` rather than passively referencing them. The AI artifacts are organized in four layers, ordered by context cost:
+
+1. **Rules** (`ai/claude-code/rules/`) — Compact pointers to full standards, auto-loaded at session start. Always in context, kept under 150 lines each.
+2. **Skills** (`templates/.claude/skills/`) — Load full standards content on demand when invoked (e.g., `/spec`, `/plan`, `/review`). Reference standards via URL so they work in any project.
+3. **Agents** (`templates/.claude/agents/`) — Specialized subagents for focused tasks like code review and spec writing, each with their own context and tool access.
+4. **Hooks** (`templates/.claude/hooks/`) — Shell/Python scripts that run automatically on tool-use events. Enforce non-negotiable rules at zero context cost.
+
+**Key principle**: Context is expensive — only load what's needed, when it's needed. Standards are enforced, not just referenced.
+
+### [Project Templates](./templates/)
+
+Starter kit for adopting these standards in new projects with Claude Code:
+
+1. Copy `templates/.claude/` into your project root as `.claude/`
+2. Copy `templates/CLAUDE.md` to your project root
+3. Customize skills, agents, hooks, and settings for your project's architecture
+
+The template includes pre-configured skills that reference the canonical standards via URL, so they stay in sync without duplication.
 
 ## Philosophy
 


### PR DESCRIPTION
## Summary

- Adds `templates/` to the Repository Structure section
- Expands the `ai/` description from a vague one-liner to a meaningful summary
- Adds new "AI / Claude Code Integration" section documenting the four-layer model (rules, skills, agents, hooks)
- Adds new "Project Templates" section with adoption steps

Closes #18

## Test plan

- [ ] Verify all new links resolve correctly
- [ ] Confirm the new sections read naturally in the flow of the existing README

https://claude.ai/code/session_01F6q1LpQBRgLahTi32hS2uy