### PR TITLE
Update hook type naming to use PascalCase format

### DIFF
--- a/templates/.claude/hooks/post-tool-use/example-notify.py
+++ b/templates/.claude/hooks/post-tool-use/example-notify.py
@@ -5,7 +5,7 @@ This hook demonstrates how to run a check or notification after Claude Code
 writes or edits a file. Replace the example logic with your project's needs
 (e.g., run a linter, validate selectors, trigger a build).
 
-Hook type: post-tool-use
+Hook type: PostToolUse
 Triggers on: Write, Edit, MultiEdit tools
 
 Exit codes:
@@ -18,7 +18,7 @@ Environment variables provided by Claude Code:
 
 Usage in .claude/settings.json:
   "hooks": {
-    "post-tool-use": [
+    "PostToolUse": [
       {
         "matcher": "Write|Edit|MultiEdit",
         "command": "python3 .claude/hooks/post-tool-use/example-notify.py"

--- a/templates/.claude/hooks/pre-tool-use/example-block.py
+++ b/templates/.claude/hooks/pre-tool-use/example-block.py
@@ -5,7 +5,7 @@ This hook demonstrates how to prevent Claude Code from writing code that
 contains a specific pattern. Replace the example logic with your project's
 rules.
 
-Hook type: pre-tool-use
+Hook type: PreToolUse
 Triggers on: Write, Edit, MultiEdit tools
 
 Exit codes:
@@ -18,7 +18,7 @@ Environment variables provided by Claude Code:
 
 Usage in .claude/settings.json:
   "hooks": {
-    "pre-tool-use": [
+    "PreToolUse": [
       {
         "matcher": "Write|Edit|MultiEdit",
         "command": "python3 .claude/hooks/pre-tool-use/example-block.py"

--- a/templates/.claude/settings.json
+++ b/templates/.claude/settings.json
@@ -14,13 +14,13 @@
     ]
   },
   "hooks": {
-    "pre-tool-use": [
+    "PreToolUse": [
       {
         "matcher": "Write|Edit|MultiEdit",
         "command": "python3 .claude/hooks/pre-tool-use/example-block.py"
       }
     ],
-    "post-tool-use": [
+    "PostToolUse": [
       {
         "matcher": "Write|Edit|MultiEdit",
         "command": "python3 .claude/hooks/post-tool-use/example-notify.py"


### PR DESCRIPTION
## Summary
Updated hook type identifiers from kebab-case to PascalCase format across configuration files and documentation examples.

## Changes
- Changed `post-tool-use` to `PostToolUse` in hook type references and configuration
- Changed `pre-tool-use` to `PreToolUse` in hook type references and configuration
- Updated `.claude/settings.json` to use the new PascalCase hook type names
- Updated example hook scripts (`example-notify.py` and `example-block.py`) to reflect the new naming convention in their documentation and usage examples

## Details
This change standardizes the hook type naming convention to PascalCase, making it consistent with common naming patterns for configuration keys and improving readability. All references in both the settings configuration and example documentation have been updated to maintain consistency.

https://claude.ai/code/session_01X1uBPw8C6hSTZjc25oAMn6