### PR TITLE
Refactor AI architecture to a 6-layer model with compound-engineering as canonical realization

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ For the architectural decision and full layer descriptions, see [ADR-0001](./doc
 
 Starter kit for adopting these standards in new projects with Claude Code:
 
-1. Copy `templates/.claude/` into your project root as `.claude/` — provides Layer 1 rule scaffolding (via `ai/claude-code/rules/`), Layer 2 (skills) and Layer 3 (agents) vendor-neutral baselines, and Layer 6 (hooks).
+1. Copy `templates/.claude/` into your project root as `.claude/` — provides Layers 2 (skills), 3 (agents), 6 (hooks) baselines plus configuration.
 2. Copy `templates/CLAUDE.md` to your project root and fill in the placeholder sections.
 3. If you adopt compound-engineering, install the plugin and consult [`process/compound-engineering-integration.md`](./process/compound-engineering-integration.md) for the operational details. CE specializes Layers 2, 3, 4, and 5 with deep implementations; Layers 1 and 6 stay owned by your project's `.claude/`.
 4. Customize hooks, skills, agents, and settings for your project's architecture.

--- a/README.md
+++ b/README.md
@@ -81,6 +81,12 @@ How to organize issues, track epics, and manage multi-issue initiatives in GitHu
 
 **Key principle**: Use GitHub's native features (sub-issues, labels, milestones) for lightweight, scalable issue organization without external tools.
 
+### [Compound Engineering Integration](./process/compound-engineering-integration.md)
+
+Operational reference for adopting [compound-engineering](https://github.com/EveryInc/compound-engineering-plugin) (CE) as the canonical realization of Layers 2–5 of the [six-layer AI architecture](./ai/claude-code/README.md). Covers artifact path mapping, ticket-tracking modes (team-scale and solo + AI), branch-naming reconciliation, AI-review discipline, and the CE skill ↔ standards doc cross-reference. Self-contained — usable by any adopter without rmorison context.
+
+**Key principle**: The architecture is the abstraction; CE is one canonical realization. Vendor-neutral baselines remain in place for projects that don't adopt the plugin.
+
 ### [Agent Transcripts](./agent-transcripts/)
 
 Conversation logs documenting the development and evolution of these standards through AI agent collaboration.
@@ -95,26 +101,33 @@ These transcripts provide historical context and reasoning behind the standards,
 
 ## AI / Claude Code Integration
 
-### [Claude Code Layer Model](./ai/claude-code/README.md)
+### [Six-Layer AI Architecture](./ai/claude-code/README.md)
 
-Defines how Claude Code actively enforces the standards in `process/` and `code/` rather than passively referencing them. The AI artifacts are organized in four layers, ordered by context cost:
+Defines how AI tooling integrates with software engineering workflows. The architecture is the **abstraction**; specific toolkits — most concretely [compound-engineering](https://github.com/EveryInc/compound-engineering-plugin) (CE) for [Claude Code](https://claude.ai/code) — fill the layers as **canonical realizations**. Vendor-neutral baselines live in this repository for projects that don't adopt a specific toolkit.
 
-1. **Rules** (`ai/claude-code/rules/`) — Compact pointers to full standards, auto-loaded at session start. Always in context, kept under 150 lines each.
-2. **Skills** (`templates/.claude/skills/`) — Load full standards content on demand when invoked (e.g., `/spec`, `/plan`, `/review`). Reference standards via URL so they work in any project.
-3. **Agents** (`templates/.claude/agents/`) — Specialized subagents for focused tasks like code review and spec writing, each with their own context and tool access.
-4. **Hooks** (`templates/.claude/hooks/`) — Shell/Python scripts that run automatically on tool-use events. Enforce non-negotiable rules at zero context cost.
+| # | Layer | Principle | Vendor-neutral baseline | Canonical realization (CE) |
+|---|-------|-----------|-------------------------|----------------------------|
+| 1 | **Rules** | Persistence — always-loaded session context | `ai/claude-code/rules/` | *(not provided by CE)* |
+| 2 | **Workflow Skills** | Composability — multi-step orchestrators | `templates/.claude/skills/` | `/ce-brainstorm`, `/ce-plan`, `/ce-work`, `/ce-doc-review`, `/ce-code-review`, `/ce-debug`, `/ce-compound`, `lfg`, … |
+| 3 | **Persona Agents** | Perspective — multiple expertises | `templates/.claude/agents/` | ~20 CE persona reviewers (coherence, feasibility, adversarial, security, …) |
+| 4 | **References** | Progressivity — context grows with workflow depth | *(none yet)* | CE skills' `references/*.md` subtrees |
+| 5 | **Compound / Learnings** | Compounding — institutional knowledge accumulates | *(none yet)* | `docs/solutions/`, `ce-compound`, `ce-compound-refresh` |
+| 6 | **Hooks** | Determinism — non-AI enforcement at zero context cost | `templates/.claude/hooks/` | *(not provided by CE)* |
 
-**Key principle**: Context is expensive — only load what's needed, when it's needed. Standards are enforced, not just referenced.
+**Key principle**: Context is expensive — only load what's needed, when it's needed. The six layers each specialize this principle for a different context-cost slot.
+
+For the architectural decision and full layer descriptions, see [ADR-0001](./docs/engineering/adr/0001-six-layer-ai-architecture.md) and [`ai/claude-code/README.md`](./ai/claude-code/README.md). For CE adoption operational details, see [`process/compound-engineering-integration.md`](./process/compound-engineering-integration.md).
 
 ### [Project Templates](./templates/)
 
 Starter kit for adopting these standards in new projects with Claude Code:
 
-1. Copy `templates/.claude/` into your project root as `.claude/`
-2. Copy `templates/CLAUDE.md` to your project root and fill in the placeholder sections
-3. Customize skills, agents, hooks, and settings for your project's architecture
+1. Copy `templates/.claude/` into your project root as `.claude/` — provides Layer 1 rule scaffolding (via `ai/claude-code/rules/`), Layer 2 (skills) and Layer 3 (agents) vendor-neutral baselines, and Layer 6 (hooks).
+2. Copy `templates/CLAUDE.md` to your project root and fill in the placeholder sections.
+3. If you adopt compound-engineering, install the plugin and consult [`process/compound-engineering-integration.md`](./process/compound-engineering-integration.md) for the operational details. CE specializes Layers 2, 3, 4, and 5 with deep implementations; Layers 1 and 6 stay owned by your project's `.claude/`.
+4. Customize hooks, skills, agents, and settings for your project's architecture.
 
-The template includes pre-configured skills that reference the canonical standards via URL, so they stay in sync without duplication.
+The vendor-neutral skills reference the canonical standards via URL, so they stay in sync without duplication.
 
 ## Philosophy
 
@@ -155,6 +168,7 @@ Modern development increasingly involves AI coding assistants. These standards w
 2. Write a strategic vision in `docs/product/strategic-vision.md`
 3. Add architecture decisions to `docs/engineering/adr/` as you make them
 4. Follow the feature development workflow for new features
+5. If adopting compound-engineering, see [`process/compound-engineering-integration.md`](./process/compound-engineering-integration.md) for path mapping (CE adds `docs/brainstorms/`, `docs/plans/`, `docs/solutions/` to the documentation tree) and review discipline.
 
 ### For Existing Projects
 

--- a/ai/CLAUDE.md
+++ b/ai/CLAUDE.md
@@ -4,6 +4,16 @@
 
 **Usage Note**: This file serves as both documentation for this repository and a template for projects following these standards. Copy and adapt the "Project-Specific Context" section for your project.
 
+## Architecture
+
+This repository follows a **six-layer AI architecture** (see [`ai/claude-code/README.md`](./claude-code/README.md) for the canonical description). The architecture is the abstraction; specific toolkits realize the layers.
+
+- **Layers 1 (Rules) and 6 (Hooks)** are owned by this repository and apply in standards-only mode and CE-mode alike.
+- **Layers 2 (Skills) and 3 (Agents)** have vendor-neutral baselines in [`templates/.claude/`](../templates/.claude/) for projects that don't run a specific toolkit. When [compound-engineering](https://github.com/EveryInc/compound-engineering-plugin) (CE) is installed, CE skills and persona reviewers are the canonical realization of those layers.
+- **Layers 4 (References) and 5 (Compound)** are realized by CE today; non-CE projects may leave them empty or fill them with hand-rolled implementations.
+
+This file holds Layer 1-style quick-reference guidance. Multi-mode rules (standards-mode default and CE-mode addendum) are noted inline below; for the CE-mode operational details, see [`process/compound-engineering-integration.md`](../process/compound-engineering-integration.md). For the architectural decision, see [ADR-0001](../docs/engineering/adr/0001-six-layer-ai-architecture.md).
+
 ---
 
 ## Core Principles
@@ -21,14 +31,20 @@
 ## Quick Reference
 
 ### Feature Development Workflow
+
+**Standards mode** (default — applies to non-CE projects):
 1. **Product Concept** → `docs/product/concepts/{feature}.md`
 2. **Requirements & Design** → `docs/product/features/{feature}.md`
 3. **Project Planning** → Break into issues with point estimates
-4. **Technical Design** → `docs/engineering/design/{feature}.md` or ADR
+4. **Technical Design** → `docs/engineering/designs/{feature}.md` or ADR
 5. **Implementation** → Code that implements the spec
 6. **Validation** → Verify against acceptance criteria
 
-📄 [Full workflow](../process/feature-development-workflow.md) | [Planning standards](../process/project-planning-standards.md)
+**When CE is in use** (additional Phase 0; CE skill outputs replace standards paths for Phases 3–4):
+- **Phase 0 (discovery)** → `docs/brainstorms/{topic}-requirements.md` (output of `/ce-brainstorm`); Phase 1 is seeded from this artifact
+- **Phase 3–4 outputs** → `docs/plans/...` (output of `/ce-plan`); subsumes `docs/planning/` for CE-using projects
+
+📄 [Full workflow](../process/feature-development-workflow.md) | [Planning standards](../process/project-planning-standards.md) | [CE integration](../process/compound-engineering-integration.md)
 
 ### Issue Organization
 - **Milestones**: Initiatives/releases (e.g., `v2.0-api-redesign`)
@@ -38,12 +54,14 @@
 📄 [Issue tracking details](../process/issue-tracking.md)
 
 ### Branching & Commits
-- **Branch naming**: `{issue-number}-{slugified-title}` (use GitHub's auto-generated names)
+- **Branch naming**:
+  - **Standards mode**: `{issue-number}-{slugified-title}` (use GitHub's auto-generated names)
+  - **When CE is in use**: also accepts topic-style `feat/...` / `fix/...` for `lfg` and `ce-work` autonomous flows without a parent issue. File an issue retroactively if review surfaces something worth tracking.
 - **Commit format**: `type(scope): description` (conventional commits)
 - **Main branch**: Always deployable, all work via PRs
 - **Versioning**: Semantic versioning (vMAJOR.MINOR.PATCH)
 
-📄 [Git branching strategy](../process/git-branching-strategy.md)
+📄 [Git branching strategy](../process/git-branching-strategy.md) | [CE integration](../process/compound-engineering-integration.md)
 
 ### Common Labels
 - **Category**: `enhancement`, `bug`, `tech-debt`, `documentation`, `testing`
@@ -52,6 +70,8 @@
 - **Points**: `points-1`, `points-2`, `points-3`, `points-5`, `points-8`, `points-13` (Fibonacci, 2 pts ≈ 1 day)
 
 ### Documentation Structure
+
+**Standards mode** (human-authored content):
 ```
 docs/
 ├── product/
@@ -59,11 +79,22 @@ docs/
 │   ├── concepts/{feature}.md
 │   └── features/{feature}.md
 └── engineering/
-    ├── design/{feature}.md
+    ├── designs/{feature}.md
     └── adr/{number}-{title}.md
 ```
 
-📄 [Documentation standards](../process/documentation-standards.md)
+**When CE is in use** (CE-skill-produced artifacts; precedence: CE owns when CE produced the file):
+```
+docs/
+├── ideation/      (ce-ideate output)
+├── brainstorms/   (ce-brainstorm output — Phase 0 / requirements)
+├── plans/         (ce-plan output — subsumes docs/planning/)
+└── solutions/     (ce-compound, ce-compound-refresh — Layer 5 artifacts)
+```
+
+Both trees coexist. Human-authored ADRs and design docs stay at the standards paths; CE skill outputs land at CE paths. For the precedence rule and provenance clause, see [`process/compound-engineering-integration.md`](../process/compound-engineering-integration.md).
+
+📄 [Documentation standards](../process/documentation-standards.md) | [CE integration](../process/compound-engineering-integration.md)
 
 ---
 
@@ -141,8 +172,24 @@ Points are for complexity, not hours. Use for planning, not performance measurem
 
 ---
 
+## When using compound-engineering
+
+When the [compound-engineering](https://github.com/EveryInc/compound-engineering-plugin) (CE) plugin is installed, CE skills and persona reviewers are the canonical realization of Layers 2 and 3 of the AI architecture (see [`ai/claude-code/README.md`](./claude-code/README.md)). CE-mode addendums:
+
+- **Artifact paths**: CE owns the artifacts it produces (`docs/brainstorms/`, `docs/plans/`, `docs/solutions/`, `docs/ideation/`); standards conventions own human-authored artifacts. Default: first-skill-touched-the-file wins. Override: `provenance:` frontmatter (`ce-plan` or `hand-authored`).
+- **Branch naming**: standards' `{issue-number}-{slugified-title}` applies when an issue exists; topic-style `feat/...` / `fix/...` is acceptable for `lfg` / `ce-work` autonomous flows without a parent issue.
+- **Phase 0 (discovery)**: `docs/brainstorms/<topic>-requirements.md` from `ce-brainstorm` IS the discovery artifact for the feature workflow; Phase 1 (Product Concept) is seeded from it.
+- **AI-review**: `ce-code-review` and `ce-doc-review` provide review **discipline** (not an enforced merge gate). Failure modes the discipline doesn't catch are named in [`process/compound-engineering-integration.md`](../process/compound-engineering-integration.md).
+
+Full operational details: [`process/compound-engineering-integration.md`](../process/compound-engineering-integration.md). Architectural decision: [ADR-0001](../docs/engineering/adr/0001-six-layer-ai-architecture.md).
+
+---
+
 ## Quick Links
 
+- [AI Architecture (six-layer model)](./claude-code/README.md)
+- [ADR-0001: Six-Layer AI Architecture](../docs/engineering/adr/0001-six-layer-ai-architecture.md)
+- [Compound Engineering Integration](../process/compound-engineering-integration.md)
 - [Documentation Standards](../process/documentation-standards.md)
 - [Feature Development Workflow](../process/feature-development-workflow.md)
 - [Project Planning Standards](../process/project-planning-standards.md)

--- a/ai/claude-code/README.md
+++ b/ai/claude-code/README.md
@@ -1,88 +1,128 @@
-# AI Artifacts Layer
+# AI Architecture
 
-This directory defines **how Claude Code operates** to produce code that meets
-the engineering standards defined in this repository. The standards in `process/`
-and `code/` define *what* good code looks like; the artifacts here ensure Claude
-Code actively follows those standards rather than passively referencing them.
+This directory describes the **AI architecture** for projects following these standards: a six-layer model that organizes AI tooling by context cost and invocation pattern.
 
-## Layer Model
+The architecture is the **abstraction**. Specific toolkits — most concretely [compound-engineering](https://github.com/EveryInc/compound-engineering-plugin) (CE) for [Claude Code](https://claude.ai/code) — fill the layers as **canonical realizations**. Vendor-neutral baselines live in this repository for projects that do not adopt a specific toolkit; the layering itself preserves vendor-neutrality.
 
-The AI artifacts are organized in four layers, ordered by context cost:
+Architectural decision: [ADR-0001](../../docs/engineering/adr/0001-six-layer-ai-architecture.md). Operational reference for CE adoption: [`process/compound-engineering-integration.md`](../../process/compound-engineering-integration.md).
 
-### Layer 1 — Rules (always loaded)
+## The Six Layers
 
-**Location:** `ai/claude-code/rules/`
+Each layer specializes a distinct **principle** for how AI capability composes with engineering work. The layers are independent slots: a project can fill some and leave others empty.
 
-Compact markdown files auto-loaded at session start. They act as **pointers**
-to the full standards — short enough to stay in context permanently without
-bloating the window. Each file stays under 150 lines.
+### Layer 1 — Rules
 
-| File | Purpose |
-|------|---------|
-| `engineering-standards.md` | References to feature workflow, documentation, git, and code quality principles |
-| `sdlc-workflow.md` | Behavioral guardrails: read before changing, plan before implementing, validate after each change |
+**Principle: persistence.** Load once per session, every session.
 
-### Layer 2 — Skills (on demand)
+Compact pointers and behavioral guardrails kept in agent context every turn. Layer 1 files load at session start and remain visible across all work. Their discipline is to stay *small* (under ~150 lines each) so the always-loaded budget stays affordable. Layer 1 typically directs the agent to the rest of the architecture rather than encoding policy inline.
 
-**Location:** `templates/.claude/skills/`
+| | |
+|---|---|
+| **Vendor-neutral baseline** | [`ai/claude-code/rules/*.md`](./rules/) (this repo) — engineering-standards pointers, SDLC behavioral guardrails |
+| **CE realization** | Not provided by CE; the standards repo retains ownership of Layer 1 |
+| **Other realizations** | `AGENTS.md`, project-root `CLAUDE.md`, IDE rule files |
 
-Skills load full standards content **only when invoked**, keeping the main
-context clean the rest of the time. They reference standards docs via GitHub
-raw URLs so they work in any project without submodules.
+### Layer 2 — Workflow Skills
 
-| Skill | Invocation | Loads | Purpose |
-|-------|-----------|-------|---------|
-| spec | `/spec` | documentation-standards.md | Draft a spec in the correct format |
-| plan | `/plan` | project-planning-standards.md | Break work into estimated, sequenced tasks |
-| review | `/review` | feature-development-workflow.md + code standards | Review code against standards |
+**Principle: composability.** Multi-step orchestrators that compose into pipelines.
 
-### Layer 3 — Agents (specialized subagents)
+Skills are slash-commands or invocable workflows that orchestrate multi-step processes. They compose into pipelines: discovery → planning → execution → review → compounding. A Layer 2 skill is *lazy-loaded* (its content enters context only when invoked), but implementations vary in depth — a vendor-neutral skill may be a thin URL-fetch template; a deeper realization may run multi-round workflows that dispatch Layer 3 personas and load Layer 4 references during execution. Both fit Layer 2.
 
-**Location:** `templates/.claude/agents/`
+| | |
+|---|---|
+| **Vendor-neutral baseline** | [`templates/.claude/skills/{spec,plan,review}/`](../../templates/.claude/skills/) — three thin URL-fetch skills that work in any project |
+| **CE realization** | ~30 skills: `/ce-brainstorm`, `/ce-plan`, `/ce-work`, `/ce-doc-review`, `/ce-code-review`, `/ce-debug`, `/ce-compound`, `lfg`, … |
+| **Other realizations** | Cursor commands, Aider commands, hand-rolled slash commands |
 
-Subagents handle focused tasks with their own context and tool access.
+### Layer 3 — Persona Agents
 
-| Agent | Type | Purpose |
-|-------|------|---------|
-| `code-reviewer.md` | Explore (read-only) | Standards-aware code review — checks separation of concerns, module boundaries |
-| `spec-writer.md` | General-purpose | Interviews user about a feature, produces a spec in the correct format |
+**Principle: perspective.** Multiple expertises analyze the same artifact.
 
-### Layer 4 — Hooks (deterministic, zero context cost)
+Agents are subagent prompt templates that encode focused domain expertise — security, performance, coherence, framework-specific style, language-specific idioms, and so on. Persona Agents are **typically dispatched by Layer 2 skills** (one orchestrator skill fans out to many personas in parallel), though simple realizations may include standalone-invocable agents. The pattern of "one skill orchestrates many personas in parallel" is what makes multi-perspective review tractable at scale.
 
-**Location:** `templates/.claude/hooks/`
+| | |
+|---|---|
+| **Vendor-neutral baseline** | [`templates/.claude/agents/{code-reviewer,spec-writer}.md`](../../templates/.claude/agents/) — two standalone-invocable agents |
+| **CE realization** | ~20 persona reviewers: coherence, feasibility, adversarial, security-lens, scope-guardian, kieran-rails, dhh-rails-style, julik-frontend-races, kieran-typescript, kieran-python, performance, reliability, … |
+| **Other realizations** | Hand-rolled subagent prompts, expertise-encoded templates |
 
-Shell or Python scripts that run automatically on tool-use events. They enforce
-non-negotiable rules without consuming context window. Written in Python for
-portability (use `uv run` if hooks need project dependencies); Bash only for
-single-line operations.
+### Layer 4 — References
 
-The template provides example hooks showing the pattern — projects replace the
-example logic with their own rules.
+**Principle: progressivity.** Context grows as workflow depth grows.
+
+References are documents *loaded by skills during execution* — not at session start (Layer 1), not at invocation (Layer 2's initial bundle), but as workflow depth grows. References allow a Layer 2 skill to remain lean at the entry point while still being able to reach for deeper context when a particular workflow branch demands it.
+
+| | |
+|---|---|
+| **Vendor-neutral baseline** | (none yet — pattern surfaced by CE; the architecture names the layer in anticipation of vendor-neutral implementations) |
+| **CE realization** | CE skills' `references/*.md` subtrees, e.g., `ce-plan/references/{plan-handoff,deepening-workflow,visual-communication,universal-planning}.md` |
+| **Other realizations** | Any progressive-loading reference pattern; Anthropic's [`Skill`](https://docs.claude.com/en/docs/agents-and-tools/agent-skills/overview) framework supports this idiomatically |
+
+### Layer 5 — Compound / Learnings
+
+**Principle: compounding.** Institutional knowledge accumulates across work.
+
+Outcomes captured from completed work that feed forward into future work — closing the loop between execution and accumulated knowledge. Layer 5 artifacts include solution documents, retrospective notes, and post-mortem records. The principle is that work *compounds*: the second similar task should be cheaper and higher-quality than the first because the first's learnings are captured and findable.
+
+| | |
+|---|---|
+| **Vendor-neutral baseline** | (none yet — pattern surfaced by CE) |
+| **CE realization** | `docs/solutions/` populated by `ce-compound` (capture) and `ce-compound-refresh` (audit and consolidate) |
+| **Other realizations** | Hand-rolled learning docs, retrospective archives, post-mortem repositories, ADR series for architectural learnings |
+
+### Layer 6 — Hooks
+
+**Principle: determinism.** Non-AI enforcement at zero context cost.
+
+Shell-level scripts that run automatically on tool-use events (`PreToolUse`, `PostToolUse`). Hooks enforce mechanical rules deterministically and consume zero AI context. They catch the kinds of mistakes (typos in file paths, write attempts to protected paths, missing pre-commit checks) that don't need AI reasoning to verify.
+
+| | |
+|---|---|
+| **Vendor-neutral baseline** | [`templates/.claude/hooks/`](../../templates/.claude/hooks/) — example pre/post-tool-use scripts |
+| **CE realization** | Not provided by CE; the standards repo retains ownership of Layer 6 |
+| **Other realizations** | Pre-commit hooks, CI guards, file-write linters, audit logs |
+
+## How the Layers Compose
+
+Layers are independent slots. A typical CE-using project fills all six. A minimal project might fill only Layers 1, 2, and 6.
+
+Pipelines are composed at Layer 2 — a sequence of skill invocations that carries an artifact from discovery to compound output:
+
+```
+brainstorm  ──▶  plan  ──▶  work  ──▶  doc-review  ──▶  code-review  ──▶  compound
+                  │           │             │                 │
+                  ▼           ▼             ▼                 ▼
+              (Layer 4   Layer 4       Layer 3            Layer 3
+              references) references)   personas          personas
+                                            │                 │
+                                            └─────────────────┴─▶  Layer 5
+                                                                    compound output
+```
+
+Each Layer 2 skill in the pipeline may dispatch Layer 3 personas (for review-shaped skills), load Layer 4 references (as workflow depth grows), and produce Layer 5 compound output (as learnings worth preserving). Layer 1 rules direct default behavior across all of the above; Layer 6 hooks enforce mechanical invariants at the shell boundary.
+
+## Design Principles
+
+- **Context is expensive — only load what's needed, when it's needed.** Each layer specializes a distinct context-cost discipline. Layer 1 stays compact because it is always loaded; Layer 2 is lazy at invocation; Layer 4 is lazy *within* invocation; Layer 6 is zero-cost at the shell boundary.
+- **Standards are enforced, not just referenced.** Layer 6 hooks catch mechanical violations. Layer 3 personas catch conceptual ones. Layer 1 rules direct the default discipline. Together the layers convert standards from documentation into operational behavior.
+- **Templates over copies.** Vendor-neutral skills (Layer 2) reference standards via URL; agents (Layer 3) point at standards docs. No content duplication to keep in sync.
+- **Projects customize, templates provide structure.** The template layer (`templates/.claude/`) gives a starting point; each project extends it. Adopting CE is one such extension.
 
 ## How to Use
 
 ### For this repository
 
-The `ai/claude-code/rules/` files are loaded automatically when working in this
-repo. They point Claude Code at the standards docs in `process/` and `code/`.
+The Layer 1 rule files in [`rules/`](./rules/) are loaded automatically when working in this repo. They direct AI tools at the standards in `process/` and `code/`. The Layer 6 example hooks in [`../../templates/.claude/hooks/`](../../templates/.claude/hooks/) are not active in this repo by default; they exist as templates for adopters.
 
 ### For new projects
 
-Copy `templates/.claude/` into your project root as `.claude/` and customize:
+1. Copy [`templates/.claude/`](../../templates/.claude/) into your project root as `.claude/` — provides Layers 2 (skills), 3 (agents), 6 (hooks) baselines plus configuration.
+2. Copy [`templates/CLAUDE.md`](../../templates/CLAUDE.md) to your project root and fill in the project-specific sections.
+3. If you adopt compound-engineering, install the plugin and consult [`process/compound-engineering-integration.md`](../../process/compound-engineering-integration.md) for the operational details (path mappings, branch-naming, AI-review discipline). CE specializes Layers 2, 3, 4, and 5 with deep implementations when present; Layers 1 and 6 remain owned by your project's `.claude/`.
+4. Customize hooks, skills, agents, and settings for your project's architecture.
 
-1. Edit `settings.json` to match your project's toolchain
-2. Keep the skills as-is (they reference standards via URL)
-3. Customize agent definitions for your project's architecture
-4. Replace example hooks with your project-specific rules
-5. Copy `templates/CLAUDE.md` to your project root and fill in the
-   project-specific sections
+## See Also
 
-## Design Principles
-
-- **Context is expensive** — only load what's needed, when it's needed
-- **Standards are enforced, not just referenced** — skills and hooks make
-  standards actionable
-- **Templates over copies** — skills point to canonical standards via URL;
-  no content duplication to keep in sync
-- **Projects customize, templates provide structure** — the template layer
-  gives a starting point; each project extends it
+- [ADR-0001: Six-Layer AI Architecture](../../docs/engineering/adr/0001-six-layer-ai-architecture.md) — the architectural decision
+- [`process/compound-engineering-integration.md`](../../process/compound-engineering-integration.md) — operational reference for CE adoption
+- [`ai/CLAUDE.md`](../CLAUDE.md) — quick-reference engineering-standards guide for AI tools

--- a/ai/claude-code/rules/engineering-standards.md
+++ b/ai/claude-code/rules/engineering-standards.md
@@ -32,21 +32,23 @@ docs/
 │   ├── concepts/{feature}.md
 │   └── features/{feature}.md
 └── engineering/
-    ├── design/{feature}.md
+    ├── designs/{feature}.md
     └── adr/{number}-{title}.md
 ```
+
+When compound-engineering is in use, additional artifact paths apply (`docs/brainstorms/`, `docs/plans/`, `docs/solutions/`, `docs/ideation/`). See [process/compound-engineering-integration.md](../../process/compound-engineering-integration.md) for the full path mapping and precedence rules.
 
 Full standard: [process/documentation-standards.md](../../process/documentation-standards.md)
 
 ## Git Conventions
 
 - **Branching**: GitHub Flow — `main` is always deployable, all work in feature branches
-- **Branch names**: `{issue-number}-{slugified-title}` (use GitHub auto-generated names)
+- **Branch names**: `{issue-number}-{slugified-title}` (use GitHub auto-generated names). When CE is in use, `lfg`/`ce-work` autonomous flows may produce topic-style branches (`feat/...`, `fix/...`) without a parent issue; see the integration doc.
 - **Commits**: Conventional format — `type(scope): description`
 - **PRs**: Small, focused, one feature/fix per branch
 - **Versioning**: Semantic versioning (vMAJOR.MINOR.PATCH)
 
-Full strategy: [process/git-branching-strategy.md](../../process/git-branching-strategy.md)
+Full strategy: [process/git-branching-strategy.md](../../process/git-branching-strategy.md). When CE is in use: [process/compound-engineering-integration.md](../../process/compound-engineering-integration.md).
 
 ## Code Quality Principles
 

--- a/ai/claude-code/rules/sdlc-workflow.md
+++ b/ai/claude-code/rules/sdlc-workflow.md
@@ -16,6 +16,8 @@ Behavioral guardrails for Claude Code sessions. Follow these in every task.
 - If the plan changes during implementation, pause and re-confirm
 - Break large changes into steps; confirm each step's approach
 
+When [compound-engineering](https://github.com/EveryInc/compound-engineering-plugin) is in use, `/ce-plan` produces the plan and `/ce-work` executes it iteratively against U-IDs and acceptance criteria; the `lfg` autonomous flow runs the discover → plan → execute → review pipeline without per-step confirmation and is appropriate when a complete plan exists. See [process/compound-engineering-integration.md](../../process/compound-engineering-integration.md).
+
 ## Validate After Each Change
 
 - After each meaningful change: run tests, run lint, confirm behavior

--- a/archive/README.md
+++ b/archive/README.md
@@ -1,0 +1,24 @@
+# Archive
+
+Documents preserved here for historical context. Their implementation strategy was superseded; the analytical content remains as the framework that informed subsequent decisions.
+
+## Agent-Native Analysis (path-not-taken)
+
+Three documents proposed building agent-native abstractions in this repository — a thin agent-native layer with workflows, learnings directories, JSON indices, parity matrices, and so on.
+
+- **[`adoption-roadmap.md`](./adoption-roadmap.md)** (2026-01-24) — phased adoption plan for agent-native principles
+- **[`agent-native-improvements.md`](./agent-native-improvements.md)** (2026-01-22) — full enumeration of 10 agent-native improvements
+- **[`top-3-enhancements.md`](./top-3-enhancements.md)** (2026-01-24) — three highest-impact items distilled from the above
+
+These were superseded by [ADR-0001: Six-Layer AI Architecture](../docs/engineering/adr/0001-six-layer-ai-architecture.md). Rather than build agent-native abstractions in-house, the repository adopted the [compound-engineering](https://github.com/EveryInc/compound-engineering-plugin) plugin as the canonical realization of Layers 2 (Workflow Skills), 3 (Persona Agents), 4 (References), and 5 (Compound / Learnings). The four-layer model these documents proposed evolved to a six-layer model that better accommodates a developed LLM-engineering system; see the ADR for the architectural reasoning.
+
+The analysis in these documents remains valid as the evaluative framework. If the canonical-realization decision is ever revisited, this analysis is the lens.
+
+## How archive works
+
+The `archive/` directory exists at the top level of the repository — outside `ai/` and `templates/` — so:
+
+- Recursive globs targeting `ai/**/*.md` or `templates/**/*.md` (which AI tools, RAG systems, and template-copying workflows often use) do not pick up archived content.
+- Adopters who copy `ai/` or `templates/` subtrees into a new project don't inherit superseded plans with broken relative ADR links.
+
+Future archived content can land here following the same pattern: relocate the file to `archive/`, add a banner pointing at the superseding decision, list it in this README.

--- a/archive/adoption-roadmap.md
+++ b/archive/adoption-roadmap.md
@@ -1,0 +1,344 @@
+# Agent-Native Adoption Roadmap
+
+> **Implementation strategy superseded by [ADR-0001: Six-Layer AI Architecture](../docs/engineering/adr/0001-six-layer-ai-architecture.md).**
+>
+> This document analyzed agent-native principles and proposed building those abstractions in this repository. We instead adopted the six-layer AI architecture (see [ADR-0001](../docs/engineering/adr/0001-six-layer-ai-architecture.md)) with [compound-engineering](https://github.com/EveryInc/compound-engineering-plugin) as the canonical realization of Layers 2 and 3. Kept here as the evaluative framework that informed the architecture — the analysis remains the lens for re-evaluating CE adoption if circumstances change. See [`process/compound-engineering-integration.md`](../process/compound-engineering-integration.md) for the operational doc.
+
+**Date**: 2026-01-24
+**Status**: Active Planning
+**Sources**:
+- [Agent-Native Guide](https://every.to/guides/agent-native) (Every.to)
+- [Compound Engineering Plugin](https://github.com/EveryInc/compound-engineering-plugin)
+
+## Overview
+
+This document consolidates two separate assessments ([agent-native-improvements.md](./agent-native-improvements.md) and compound engineering analysis) into a single, practical adoption plan. Rather than 17 separate improvements, we've identified 5 core themes with incremental implementation steps.
+
+## Core Themes (Consolidation)
+
+### Theme 1: Knowledge Compounding
+**Combines**: Agent-Native #6 (Emergent Capability), #8 (Iterative Improvement), Compound Engineering #1 (Compound Step), #2 (Learnings Repository)
+
+**Core Idea**: Each completed task should make future tasks easier through systematic knowledge capture and reuse.
+
+### Theme 2: Clear Completion & Quality Signals
+**Combines**: Agent-Native #2 (Completion Criteria), #9 (Enhanced Transcripts), Compound Engineering #3 (Multi-Perspective Review), #7 (Retrospective)
+
+**Core Idea**: Agents and humans need explicit signals for when work is complete and what quality means.
+
+### Theme 3: Atomic, Composable Content
+**Combines**: Agent-Native #3 (Atomic Decomposition), Compound Engineering #5 (Workflow Skills)
+
+**Core Idea**: Break standards and workflows into small, reusable pieces that can be combined as needed.
+
+### Theme 4: Contextual Intelligence
+**Combines**: Agent-Native #1 (Standards Index), #5 (Context Injection), #10 (Project State)
+
+**Core Idea**: Provide agents quick access to relevant standards, context, and project state without reading everything.
+
+### Theme 5: Research & Planning Emphasis
+**Combines**: Agent-Native #7 (Parity Matrix), Compound Engineering #4 (Pre-Implementation Research), #6 (80/20 Planning)
+
+**Core Idea**: Invest more time in research and planning to make execution faster and higher quality.
+
+---
+
+## Phased Adoption Plan
+
+### Phase 1: Foundation (Weeks 1-2)
+**Goal**: Establish knowledge capture habits and basic structure
+
+#### Week 1: Add Knowledge Compounding
+
+**Step 1.1: Add "Compound" step to workflows** ⏱️ 30 minutes
+- Update `process/feature-development-workflow.md`
+- Update `process/technical-work-workflow.md`
+- Add Phase 7: "Compound (Knowledge Capture)" with checklist
+
+**Step 1.2: Create learnings directory structure** ⏱️ 15 minutes
+```bash
+mkdir -p ai/learnings
+touch ai/learnings/README.md
+```
+
+**Step 1.3: Create task retrospective template** ⏱️ 20 minutes
+- Create `templates/task-retrospective.md`
+- Include sections: What Went Well, Challenges, Learnings, Compound Actions
+
+**Success metric**: Next completed task includes a retrospective and learning documentation
+
+#### Week 2: Improve Completion Clarity
+
+**Step 1.4: Add explicit completion checklists** ⏱️ 45 minutes
+- Add "Definition of Done" checklists to both workflow documents
+- Include agent-verifiable criteria (tests pass, docs updated, etc.)
+
+**Step 1.5: Enhance agent transcript template** ⏱️ 30 minutes
+- Update `agent-transcripts/README.md` with structured format
+- Include: Task, Standards Applied, Outcome, Tools Used, Learnings
+
+**Step 1.6: Create first learning document** ⏱️ 45 minutes
+- Create `ai/learnings/standards-creation.md`
+- Document insights from Python standards creation
+- Establish pattern for future learning docs
+
+**Success metric**: Clear criteria exist for when any task is "done"
+
+---
+
+### Phase 2: Practical Tools (Weeks 3-4)
+**Goal**: Build reusable workflows and make content more discoverable
+
+#### Week 3: Workflow Skills Library
+
+**Step 2.1: Create workflow skills structure** ⏱️ 20 minutes
+```bash
+mkdir -p ai/workflows
+touch ai/workflows/README.md
+```
+
+**Step 2.2: Build 3 essential workflows** ⏱️ 90 minutes each
+- `ai/workflows/bug-investigation.md` - Systematic debugging approach
+- `ai/workflows/feature-implementation.md` - Step-by-step feature building
+- `ai/workflows/standard-creation.md` - Creating new standards (meta!)
+
+**Step 2.3: Cross-reference from CLAUDE.md** ⏱️ 20 minutes
+- Add "Workflow Skills" section to `ai/CLAUDE.md`
+- Link to workflow directory
+
+**Success metric**: Next bug or feature uses a workflow skill as guide
+
+#### Week 4: Better Content Discovery
+
+**Step 2.4: Restructure CLAUDE.md** ⏱️ 2 hours
+- Split into focused files:
+  - `ai/principles.md` (core principles)
+  - `ai/context/estimation-scales.md`
+  - `ai/context/issue-patterns.md`
+- Update `ai/CLAUDE.md` to be a navigation/overview file
+
+**Step 2.5: Add standards quick reference** ⏱️ 1 hour
+- Create `ai/standards-quick-ref.md`
+- Table format: Standard, When to Use, Key Points, Full Link
+- Lightweight alternative to full JSON index
+
+**Success metric**: CLAUDE.md is under 200 lines, standards are quickly findable
+
+---
+
+### Phase 3: Advanced Capabilities (Weeks 5-6)
+**Goal**: Enable deeper agent capabilities and systematic improvement
+
+#### Week 5: Multi-Perspective Review
+
+**Step 3.1: Create code review standard** ⏱️ 90 minutes
+- New file: `process/code-review-standards.md`
+- Include review perspectives: Security, Performance, Architecture, Testing
+- Add checklists for each perspective
+
+**Step 3.2: Add research phase to technical design** ⏱️ 45 minutes
+- Update `process/feature-development-workflow.md` Phase 4
+- Add "Research Before Design" section
+- Include: codebase patterns, external best practices, historical context
+
+**Step 3.3: Document 80/20 planning principle** ⏱️ 30 minutes
+- Add to `README.md` Philosophy section
+- Add to `ai/principles.md`
+- Emphasize planning investment over execution speed
+
+**Success metric**: Next complex PR uses multi-perspective review checklist
+
+#### Week 6: Contextual Intelligence
+
+**Step 3.4: Create context injection template** ⏱️ 30 minutes
+- Create `templates/.agent-context.md`
+- Add to `.gitignore`
+- Document when/how to use in `ai/CLAUDE.md`
+
+**Step 3.5: Build lightweight project state** ⏱️ 1 hour
+- Create `.project-status.json` with: active work, recent completions, known issues
+- Add "update project status" to compound step checklist
+- Start simple, expand over time
+
+**Step 3.6: Create parity matrix** ⏱️ 1 hour
+- New file: `ai/parity-matrix.md`
+- Map human actions → agent capabilities → gaps
+- Identify top 3 capability gaps to address
+
+**Success metric**: Agents understand project state without lengthy explanations
+
+---
+
+### Phase 4: Continuous Improvement (Ongoing)
+**Goal**: Establish feedback loops and evolving standards
+
+#### Ongoing Activities
+
+**Activity 4.1: Weekly learning documentation** ⏱️ 15 min/week
+- Every completed task: Update relevant learning document
+- Create new learning docs as domains emerge
+
+**Activity 4.2: Monthly standard refinement** ⏱️ 1 hour/month
+- Review `ai/learnings/` for patterns
+- Propose standard updates based on accumulated insights
+- Track in `ai/improvement-suggestions.md`
+
+**Activity 4.3: Quarterly retrospective** ⏱️ 2 hours/quarter
+- Review adoption effectiveness
+- Identify successful patterns
+- Prune or revise tools that aren't working
+- Update adoption roadmap
+
+**Success metric**: Standards evolve based on real usage, agent effectiveness increases over time
+
+---
+
+## Implementation Principles
+
+### Start Small, Compound Over Time
+Don't try to implement everything at once. Each phase builds on the previous one. The compounding effect comes from consistent application, not comprehensive adoption.
+
+### Favor Practice Over Perfection
+A simple learning document used regularly beats a comprehensive system used never. Start with basic formats and let them evolve through use.
+
+### Measure by Effectiveness, Not Completion
+Success isn't "did we implement all 17 improvements?" It's "are agents more effective? Are tasks getting easier?"
+
+### Maintain Lightweight Philosophy
+If an addition feels heavy or bureaucratic, simplify it. These tools should enable work, not create overhead.
+
+---
+
+## Priority Matrix
+
+### Must Have (Do First)
+- Theme 1: Knowledge Compounding (Phase 1, Week 1-2)
+- Theme 2: Completion Signals (Phase 1, Week 2)
+
+**Rationale**: These provide immediate value and establish the foundation for everything else.
+
+### Should Have (High Value)
+- Theme 3: Atomic Content (Phase 2, Week 4)
+- Theme 2: Workflow Skills (Phase 2, Week 3)
+
+**Rationale**: Make existing content more usable and add practical tools.
+
+### Could Have (Incremental Value)
+- Theme 5: Research/Planning Emphasis (Phase 3, Week 5)
+- Theme 4: Contextual Intelligence (Phase 3, Week 6)
+
+**Rationale**: Valuable but can wait until foundation is solid.
+
+### Won't Have (Yet)
+- Agent-Native #4: Validation scripts (automation premature)
+- Full JSON standards index (quick-ref sufficient)
+
+**Rationale**: These add complexity without clear immediate value. Revisit in Phase 4+ based on real needs.
+
+---
+
+## Success Indicators
+
+Track these qualitative signals to assess adoption effectiveness:
+
+### Agent Effectiveness
+- ✅ Agents ask fewer clarification questions
+- ✅ Agents reference learnings documents unprompted
+- ✅ Agents complete tasks in fewer iterations
+- ✅ Agents suggest improvements to standards
+
+### Knowledge Accumulation
+- ✅ Learning documents grow with each task
+- ✅ Retrospectives capture valuable insights
+- ✅ Standards improve based on real experience
+- ✅ New team members/agents onboard faster
+
+### Quality Signals
+- ✅ "Definition of done" prevents incomplete work
+- ✅ Review checklists catch issues earlier
+- ✅ Less rework required after task completion
+- ✅ Fewer repeat mistakes
+
+### Workflow Efficiency
+- ✅ Tasks start faster (less research duplicated)
+- ✅ Planning phase is more thorough
+- ✅ Similar tasks show measurable improvement
+- ✅ Context switching is faster
+
+---
+
+## Decision Log
+
+### Why This Consolidation?
+
+**Original situation**:
+- 10 agent-native improvements
+- 7 compound engineering additions
+- 17 total items, unclear priorities, significant overlap
+
+**Problems**:
+- Too many things to track
+- Unclear what to do first
+- Overlapping concepts confusing
+- Risk of analysis paralysis
+
+**Solution**:
+- Consolidated into 5 core themes
+- Phased adoption plan (6 weeks + ongoing)
+- Time estimates for each step
+- Clear success metrics
+
+**Trade-offs**:
+- Some specificity lost in consolidation
+- Original documents still valuable as reference
+- This is an interpretation, not gospel
+
+### Why These Phases?
+
+**Phase 1**: Foundation habits (compounding, completion)
+- Most impactful practices
+- Establish the feedback loop
+- Quick wins build momentum
+
+**Phase 2**: Practical tools (workflows, discovery)
+- Support the foundation with actual tools
+- Make existing content more usable
+- Still relatively quick to implement
+
+**Phase 3**: Advanced capabilities (review, context, research)
+- Build on established foundation
+- More sophisticated but require base practices
+- Higher effort, incremental value
+
+**Phase 4**: Continuous improvement (ongoing)
+- Perpetual refinement based on Phase 1-3 experience
+- The compounding effect in action
+
+---
+
+## Next Steps
+
+1. **Review this roadmap** - Does it make sense? Any adjustments needed?
+
+2. **Start Phase 1, Week 1** - Begin with knowledge compounding:
+   - Update workflow documents (Step 1.1)
+   - Create learnings directory (Step 1.2)
+   - Create retrospective template (Step 1.3)
+
+3. **Apply to next task** - Use the new compound step and retrospective on the very next completed task
+
+4. **Iterate** - Adjust the roadmap based on what works and what doesn't
+
+---
+
+## References
+
+- [Agent-Native Improvements](./agent-native-improvements.md) - Original assessment #1
+- [Compound Engineering Plugin](https://github.com/EveryInc/compound-engineering-plugin) - Source for assessment #2
+- [Engineering Standards README](../README.md) - Our philosophy and current structure
+- [CLAUDE.md](./CLAUDE.md) - Current AI assistant guide
+
+---
+
+**Last Updated**: 2026-01-24
+**Status**: Ready for review and Phase 1 implementation

--- a/archive/adoption-roadmap.md
+++ b/archive/adoption-roadmap.md
@@ -2,7 +2,7 @@
 
 > **Implementation strategy superseded by [ADR-0001: Six-Layer AI Architecture](../docs/engineering/adr/0001-six-layer-ai-architecture.md).**
 >
-> This document analyzed agent-native principles and proposed building those abstractions in this repository. We instead adopted the six-layer AI architecture (see [ADR-0001](../docs/engineering/adr/0001-six-layer-ai-architecture.md)) with [compound-engineering](https://github.com/EveryInc/compound-engineering-plugin) as the canonical realization of Layers 2 and 3. Kept here as the evaluative framework that informed the architecture — the analysis remains the lens for re-evaluating CE adoption if circumstances change. See [`process/compound-engineering-integration.md`](../process/compound-engineering-integration.md) for the operational doc.
+> This document analyzed agent-native principles and proposed building those abstractions in this repository. We instead adopted the six-layer AI architecture (see [ADR-0001](../docs/engineering/adr/0001-six-layer-ai-architecture.md)) with [compound-engineering](https://github.com/EveryInc/compound-engineering-plugin) as the canonical realization of Layers 2 (Workflow Skills), 3 (Persona Agents), 4 (References), and 5 (Compound / Learnings). Kept here as the evaluative framework that informed the architecture — the analysis remains the lens for re-evaluating CE adoption if circumstances change. See [`process/compound-engineering-integration.md`](../process/compound-engineering-integration.md) for the operational doc.
 
 **Date**: 2026-01-24
 **Status**: Active Planning

--- a/archive/agent-native-improvements.md
+++ b/archive/agent-native-improvements.md
@@ -2,7 +2,7 @@
 
 > **Implementation strategy superseded by [ADR-0001: Six-Layer AI Architecture](../docs/engineering/adr/0001-six-layer-ai-architecture.md).**
 >
-> This document analyzed agent-native principles and proposed building those abstractions in this repository. We instead adopted the six-layer AI architecture (see [ADR-0001](../docs/engineering/adr/0001-six-layer-ai-architecture.md)) with [compound-engineering](https://github.com/EveryInc/compound-engineering-plugin) as the canonical realization of Layers 2 and 3. Kept here as the evaluative framework that informed the architecture — the analysis remains the lens for re-evaluating CE adoption if circumstances change. See [`process/compound-engineering-integration.md`](../process/compound-engineering-integration.md) for the operational doc.
+> This document analyzed agent-native principles and proposed building those abstractions in this repository. We instead adopted the six-layer AI architecture (see [ADR-0001](../docs/engineering/adr/0001-six-layer-ai-architecture.md)) with [compound-engineering](https://github.com/EveryInc/compound-engineering-plugin) as the canonical realization of Layers 2 (Workflow Skills), 3 (Persona Agents), 4 (References), and 5 (Compound / Learnings). Kept here as the evaluative framework that informed the architecture — the analysis remains the lens for re-evaluating CE adoption if circumstances change. See [`process/compound-engineering-integration.md`](../process/compound-engineering-integration.md) for the operational doc.
 
 **Date**: 2026-01-22
 **Source**: [Agent-Native Guide](https://every.to/guides/agent-native) from Every.to

--- a/archive/agent-native-improvements.md
+++ b/archive/agent-native-improvements.md
@@ -1,0 +1,414 @@
+# Agent-Native Architecture Improvements
+
+> **Implementation strategy superseded by [ADR-0001: Six-Layer AI Architecture](../docs/engineering/adr/0001-six-layer-ai-architecture.md).**
+>
+> This document analyzed agent-native principles and proposed building those abstractions in this repository. We instead adopted the six-layer AI architecture (see [ADR-0001](../docs/engineering/adr/0001-six-layer-ai-architecture.md)) with [compound-engineering](https://github.com/EveryInc/compound-engineering-plugin) as the canonical realization of Layers 2 and 3. Kept here as the evaluative framework that informed the architecture — the analysis remains the lens for re-evaluating CE adoption if circumstances change. See [`process/compound-engineering-integration.md`](../process/compound-engineering-integration.md) for the operational doc.
+
+**Date**: 2026-01-22
+**Source**: [Agent-Native Guide](https://every.to/guides/agent-native) from Every.to
+**Status**: Proposed
+
+## Overview
+
+This document outlines suggestions for incorporating agent-native design principles into our engineering standards repository. These improvements aim to make our standards more accessible and actionable for AI assistants while maintaining human readability.
+
+## Agent-Native Principles
+
+The Every.to guide establishes five core principles for building agent-native applications:
+
+1. **Parity**: Whatever the user can do through the UI, the agent should be able to achieve through tools
+2. **Granularity**: Tools should be atomic primitives rather than bundling decision logic
+3. **Composability**: With atomic tools and parity, new features emerge through descriptive prompts
+4. **Emergent Capability**: Agents accomplish tasks designers didn't explicitly anticipate
+5. **Improvement Over Time**: Applications evolve through accumulated context and prompt refinement
+
+## Current Strengths
+
+Our repository already embraces several agent-native concepts:
+
+- **File-first architecture**: Extensive use of markdown documents
+- **Shared workspace**: The `/ai/CLAUDE.md` guide puts AI assistants and humans in the same context
+- **Transparent process**: Agent transcripts document how standards were created
+- **Composability**: Modular standards that can be applied independently
+
+## Proposed Improvements
+
+### 1. Agent-Accessible Standard Reference System
+
+Create a machine-readable index alongside markdown files to enable quick standard lookup.
+
+**Implementation**:
+```
+/code/standards-index.json
+{
+  "standards": [
+    {
+      "id": "python-testing",
+      "path": "/code/python-standards.md#testing",
+      "category": "code-quality",
+      "applies_to": ["python"],
+      "keywords": ["pytest", "unit-tests", "coverage"],
+      "atomic_rules": [
+        "Use pytest as the testing framework",
+        "Maintain 80% code coverage minimum"
+      ]
+    }
+  ]
+}
+```
+
+**Benefits**:
+- Agents can locate specific standards without parsing entire documents
+- Enables semantic search across standards
+- Supports automated compliance checking
+
+### 2. Explicit Completion Criteria
+
+Enhance process documents with agent-checkable completion signals.
+
+**Implementation**:
+```markdown
+## Feature Completion Checklist (Agent-Verifiable)
+
+- [ ] `STATUS: implementation-complete` flag in issue
+- [ ] All acceptance criteria have `[x]` checked
+- [ ] CI pipeline shows green status
+- [ ] `docs/` directory contains updated documentation
+- [ ] CHANGELOG.md has entry for this version
+```
+
+**Benefits**:
+- Agents know when tasks are truly complete
+- Reduces back-and-forth asking "is this done?"
+- Creates verifiable audit trail
+
+### 3. Atomic Standard Decomposition
+
+Break down `/ai/CLAUDE.md` into more granular, composable pieces.
+
+**Implementation**:
+```
+/ai/
+  ├── README.md (overview)
+  ├── principles.md (core principles)
+  ├── workflows/
+  │   ├── feature-development.md
+  │   ├── bug-fixing.md
+  │   └── code-review.md
+  ├── context/
+  │   ├── estimation-scales.md
+  │   ├── issue-patterns.md
+  │   └── project-structure.md
+  └── tools/
+      ├── available-commands.md
+      └── verification-scripts.md
+```
+
+**Benefits**:
+- Agents load only relevant context for specific tasks
+- Reduces token usage and improves response time
+- Easier to maintain and update individual pieces
+
+### 4. Standard Application Templates
+
+Add agent-executable validation scripts.
+
+**Implementation**:
+```python
+# /tools/validate-python-standard.py
+"""
+Verifies a Python project meets engineering standards.
+Agents can run this to confirm compliance.
+"""
+
+def check_project_structure():
+    """Returns list of violations or empty list if compliant"""
+    required_files = ['pyproject.toml', 'README.md', 'tests/']
+    violations = []
+    # Check logic here
+    return violations
+
+def check_dependencies():
+    """Validates pyproject.toml matches standards"""
+    pass
+
+def generate_compliance_report():
+    """Creates markdown report of standard compliance"""
+    pass
+```
+
+**Benefits**:
+- Automated standard validation
+- Consistent compliance checking
+- Agents can verify their work meets standards
+
+### 5. Context Injection Files
+
+Create session-specific context files that agents can read.
+
+**Implementation**:
+```markdown
+# .agent-context.md (git-ignored, ephemeral)
+
+## Current Session
+- **Task**: Implement user authentication
+- **Active Branch**: feature/auth-system
+- **Relevant Standards**: /code/python-standards.md#security, /process/feature-development-workflow.md
+- **Recent Decisions**: Using JWT tokens (decided in issue #42)
+- **Open Questions**: Session timeout duration (ask user)
+```
+
+**Update `.gitignore`**:
+```
+# Agent session context (ephemeral)
+.agent-context.md
+```
+
+**Benefits**:
+- Agents maintain context across sessions
+- Reduces need to re-explain project state
+- Documents decisions and rationale
+
+### 6. Emergent Capability Documentation
+
+Track unexpected but valuable agent behaviors.
+
+**Implementation**:
+```markdown
+# /ai/emergent-patterns.md
+
+## Discovered Agent Capabilities
+
+### Automatic Standard Cross-Referencing
+- **Emerged**: 2026-01-15
+- **Description**: Agent began linking related standards across documents
+- **Value**: Improved consistency checking
+- **How to Replicate**: Include instruction in CLAUDE.md
+- **Example**: See transcript 2026-01-15-code-review.md
+
+### Proactive Security Scanning
+- **Emerged**: 2026-01-18
+- **Description**: Agent suggested security scans without being asked
+- **Value**: Caught vulnerability before deployment
+- **How to Replicate**: Add security checklist to code review workflow
+```
+
+**Benefits**:
+- Captures valuable behaviors for replication
+- Improves standards over time based on actual usage
+- Creates feedback loop for continuous improvement
+
+### 7. Parity with Human Workflows
+
+Ensure every human process has an agent-equivalent.
+
+**Analysis**:
+
+| Human Action | Current Agent Access | Gap | Recommendation |
+|-------------|---------------------|-----|----------------|
+| Create issue from template | Can read templates | No write access to GitHub | Document issue creation checklist agents can populate |
+| Run estimation meeting | Can read scale | No facilitation process | Add `/ai/workflows/estimation.md` |
+| Review PR | Can read code | No approval mechanism | Document review checklist agents can populate |
+| Update documentation | Can edit markdown | No doc structure guide | Add documentation templates |
+| Deploy to production | Can read deploy docs | No execution access | Document pre/post-deploy checklists |
+
+**Implementation**: Create `/ai/parity-matrix.md` tracking agent capabilities vs. human workflows.
+
+**Benefits**:
+- Identifies gaps in agent capabilities
+- Ensures agents can fully participate in workflows
+- Guides tool development priorities
+
+### 8. Iterative Improvement Mechanism
+
+Create a feedback loop for standard evolution.
+
+**Implementation**:
+```markdown
+# /ai/improvements.md
+
+## Standard Refinements Suggested by Agents
+
+### Week of 2026-01-20
+- **Suggested**: Add security scanning to Python standards
+- **Context**: Agent encountered vulnerability during code review
+- **Status**: Accepted, updated python-standards.md
+- **PR**: #123
+
+### Week of 2026-01-27
+- **Suggested**: Clarify when to use feature vs. technical workflow
+- **Context**: Agent unsure which process to follow for refactoring
+- **Status**: Under review
+- **Discussion**: Issue #125
+```
+
+**Benefits**:
+- Standards evolve based on real usage
+- Captures pain points and ambiguities
+- Transparent improvement process
+
+### 9. Enhanced Agent Transcripts
+
+Structure transcripts for maximum learning value.
+
+**Implementation**:
+```markdown
+# Format: YYYY-MM-DD-{task}-{outcome}.md
+
+## Transcript Metadata
+- **Task**: Implement user authentication
+- **Standards Applied**:
+  - /process/feature-development-workflow.md
+  - /code/python-standards.md#security
+- **Outcome**: Success (merged to main)
+- **Duration**: 3 sessions over 2 days
+
+## Completion Signals Observed
+- All acceptance criteria checked
+- CI pipeline green
+- Documentation updated
+
+## Tools Used
+- pytest for test coverage
+- ruff for linting
+- mypy for type checking
+- gh CLI for PR creation
+
+## Emergent Behaviors
+- Agent proactively suggested rate limiting
+- Cross-referenced OWASP standards without prompting
+
+## Improvement Suggestions
+- Security checklist would have streamlined review
+- Clearer guidance on when to add logging
+```
+
+**Benefits**:
+- Transcripts become training material
+- Patterns emerge from multiple sessions
+- Identifies standard gaps and improvements
+
+### 10. Agent-Readable Project State
+
+Add persistent state tracking that both humans and agents maintain.
+
+**Implementation**:
+```json
+# .project-status.json (committed to repo)
+{
+  "last_updated": "2026-01-22T14:30:00Z",
+  "active_standards_version": "v1.2.0",
+  "compliance_status": {
+    "python": "compliant",
+    "documentation": "partial",
+    "security": "in-progress"
+  },
+  "active_work": [
+    {
+      "issue": "#45",
+      "standard": "feature-development-workflow",
+      "current_step": "implementation",
+      "started": "2026-01-20"
+    }
+  ],
+  "recent_completions": [
+    {
+      "issue": "#42",
+      "completed": "2026-01-19",
+      "standards_applied": ["python-standards", "git-branching-strategy"]
+    }
+  ],
+  "known_issues": [
+    {
+      "description": "Test coverage below 80% in auth module",
+      "tracking": "#46",
+      "impact": "blocks release"
+    }
+  ]
+}
+```
+
+**Benefits**:
+- Agents understand project state immediately
+- Reduces "what's the status?" questions
+- Enables progress tracking and reporting
+
+## Implementation Priority
+
+### High Impact, Low Effort (Start Here)
+1. **Explicit Completion Criteria** (#2)
+   - Add to existing process documents
+   - Immediate improvement in agent clarity
+
+2. **Atomic Standard Decomposition** (#3)
+   - Restructure `/ai/CLAUDE.md`
+   - Better context loading
+
+### Medium Priority
+3. **Standards Index** (#1)
+   - JSON index of all standards
+   - Enables quick lookup
+
+4. **Context Injection Files** (#5)
+   - Add `.agent-context.md` template
+   - Update `.gitignore`
+
+5. **Enhanced Transcripts** (#9)
+   - Add metadata template
+   - Richer learning data
+
+### Long Term
+6. **Parity Analysis** (#7)
+   - Document capability gaps
+   - Guide future development
+
+7. **Project State Tracking** (#10)
+   - Implement `.project-status.json`
+   - Maintain in workflows
+
+8. **Validation Tools** (#4)
+   - Build compliance checkers
+   - Automated verification
+
+9. **Emergent Patterns** (#6)
+   - Document valuable behaviors
+   - Continuous improvement
+
+10. **Improvement Mechanism** (#8)
+    - Feedback loop process
+    - Standard evolution tracking
+
+## Success Metrics
+
+Track these indicators to measure agent-native improvements:
+
+- **Reduced clarification questions**: Agents need less back-and-forth to understand requirements
+- **Increased standard compliance**: Automated checks show higher conformance
+- **Faster task completion**: Agents complete tasks with fewer iterations
+- **Emergent behaviors documented**: New valuable patterns identified monthly
+- **Standard updates from agent feedback**: Standards improve based on actual usage
+
+## Next Steps
+
+1. Review this proposal with team
+2. Prioritize improvements based on current pain points
+3. Create issues for approved improvements
+4. Implement incrementally following our own standards
+5. Document learnings in agent transcripts
+
+## References
+
+- [Agent-Native Guide](https://every.to/guides/agent-native) - Every.to
+- `/ai/CLAUDE.md` - Current AI assistant guide
+- `/agent-transcripts/` - Existing agent session records
+- `/process/` - Current process standards
+
+## Notes
+
+These improvements align with our philosophy of:
+- Lightweight process (add only what provides value)
+- Spec-driven development (explicit > implicit)
+- GitHub-native workflows (use built-in features)
+- AI-native development (design for human-AI collaboration)
+
+The goal is to make our standards more actionable for agents while maintaining human readability and our commitment to avoiding process overhead.

--- a/archive/top-3-enhancements.md
+++ b/archive/top-3-enhancements.md
@@ -1,0 +1,261 @@
+# Top 3 Agent-Native Enhancements
+
+> **Implementation strategy superseded by [ADR-0001: Six-Layer AI Architecture](../docs/engineering/adr/0001-six-layer-ai-architecture.md).**
+>
+> This document analyzed agent-native principles and proposed building those abstractions in this repository. We instead adopted the six-layer AI architecture (see [ADR-0001](../docs/engineering/adr/0001-six-layer-ai-architecture.md)) with [compound-engineering](https://github.com/EveryInc/compound-engineering-plugin) as the canonical realization of Layers 2 and 3. Kept here as the evaluative framework that informed the architecture — the analysis remains the lens for re-evaluating CE adoption if circumstances change. See [`process/compound-engineering-integration.md`](../process/compound-engineering-integration.md) for the operational doc.
+
+**Date**: 2026-01-24
+**Status**: Approved for Implementation
+
+Based on analysis of the [Compound Engineering Plugin](https://github.com/EveryInc/compound-engineering-plugin) and [Every.to Agent-Native Guide](https://every.to/guides/agent-native), these are the 3 highest-impact additions to this repository:
+
+---
+
+## 1. Knowledge Compounding (The "Compound" Step)
+
+**Problem**: Each task starts fresh. We don't systematically capture what we learn, so we repeat mistakes and duplicate research.
+
+**Solution**: Add a "Compound" step after task completion to capture learnings.
+
+**Implementation**:
+1. Add Phase 7 "Compound" to both workflow documents
+2. Create `/ai/learnings/` directory structure
+3. Create `templates/task-retrospective.md`
+
+**What to capture**:
+- Challenges encountered and solutions found
+- Code patterns that worked well
+- Gotchas and pitfalls to avoid
+- Standards gaps discovered
+- Tools/techniques that proved valuable
+
+**Where to document**:
+- Quick insights → `/ai/learnings/{domain}.md` (e.g., python.md, testing.md)
+- Significant decisions → ADR in `docs/engineering/adr/`
+- Workflow improvements → PR to relevant standard
+- Novel behaviors → `/ai/emergent-patterns.md`
+
+**Example**:
+```markdown
+# /ai/learnings/python.md
+
+## Testing Patterns
+
+### Async Test Fixtures (Issue #42, 2026-01-20)
+- **Challenge**: Async database tests were flaky
+- **Solution**: Use `pytest-asyncio` with `scope="function"`
+- **Gotcha**: Don't mix sync and async fixtures in same test
+- **Code**: See `tests/conftest.py:25-40`
+```
+
+**Impact**: Future similar tasks start with accumulated knowledge instead of from scratch.
+
+**Effort**: ~1 hour setup + 10-15 min per task to document learnings
+
+---
+
+## 2. Explicit Completion Criteria
+
+**Problem**: Ambiguity about when work is "done" leads to incomplete tasks, back-and-forth clarification, and quality issues.
+
+**Solution**: Add clear, agent-verifiable "Definition of Done" checklists to all workflows.
+
+**Implementation**:
+Add to both `process/feature-development-workflow.md` and `process/technical-work-workflow.md`:
+
+```markdown
+## Definition of Done
+
+A task is complete when ALL of these criteria are met:
+
+**Code Complete**:
+- [ ] All acceptance criteria from spec are implemented
+- [ ] Code follows language standards (e.g., `code/python-standards.md`)
+- [ ] No compiler/linter warnings introduced
+
+**Quality Verified**:
+- [ ] Tests written and passing (unit + integration as needed)
+- [ ] Code coverage meets standards (80% for new code)
+- [ ] Manual testing completed (if UI/integration work)
+- [ ] Security review completed (if security-relevant)
+
+**Documentation Current**:
+- [ ] Code comments added where logic is non-obvious
+- [ ] README/docs updated if behavior changed
+- [ ] ADR created if significant technical decision made
+
+**Integration Ready**:
+- [ ] CI/CD pipeline passing (all checks green)
+- [ ] Branch rebased on latest main (no conflicts)
+- [ ] PR description complete with summary and testing notes
+
+**Knowledge Captured**:
+- [ ] Retrospective completed (if non-trivial task)
+- [ ] Learnings documented in `/ai/learnings/`
+- [ ] Any standards gaps noted as issues
+```
+
+**Impact**: Clear finish line reduces rework, catches incomplete work early, creates consistent quality bar.
+
+**Effort**: ~30 minutes to add checklists
+
+---
+
+## 3. Workflow Skills Library
+
+**Problem**: Common tasks (debugging, feature implementation, refactoring) are done inconsistently. Each time we reinvent the approach.
+
+**Solution**: Create reusable workflow guides for frequent task types.
+
+**Implementation**:
+Create `/ai/workflows/` directory with these essential workflows:
+
+### `/ai/workflows/bug-investigation.md`
+```markdown
+## Bug Investigation Workflow
+
+### 1. Reproduce (Goal: Minimal repro case)
+- [ ] Document exact steps to trigger bug
+- [ ] Identify affected versions/environments
+- [ ] Create minimal code example that reproduces issue
+
+### 2. Research (Goal: Context and similar issues)
+- [ ] Search issue tracker for similar reports
+- [ ] Review recent changes: `git log --since="2 weeks ago" -- {affected_files}`
+- [ ] Check `/ai/learnings/` for related gotchas
+- [ ] Search framework/library issue trackers
+
+### 3. Investigate (Goal: Root cause hypothesis)
+- [ ] Add logging to narrow scope
+- [ ] Use debugger to examine state at failure point
+- [ ] Form hypothesis of root cause
+- [ ] Verify hypothesis with targeted test
+
+### 4. Document (Goal: Clear record for fix)
+- [ ] Update issue with reproduction steps
+- [ ] Document root cause analysis in issue comments
+- [ ] Create failing test that demonstrates bug
+- [ ] Note any related bugs that might exist
+
+### 5. Fix & Compound (Goal: Prevent recurrence)
+- [ ] Implement fix
+- [ ] Verify fix with reproduction test
+- [ ] Add to `/ai/learnings/` if gotcha discovered
+- [ ] Search codebase for similar patterns that might have same bug
+```
+
+### `/ai/workflows/feature-implementation.md`
+```markdown
+## Feature Implementation Workflow
+
+### 1. Understand Spec (Goal: Clear requirements)
+- [ ] Read product spec in `docs/product/features/`
+- [ ] Read technical design in `docs/engineering/design/`
+- [ ] Review acceptance criteria
+- [ ] List any unclear requirements (ask before coding)
+
+### 2. Research (Goal: Informed approach)
+- [ ] Search codebase for similar features: `grep -r "similar pattern"`
+- [ ] Review `/ai/learnings/` for relevant insights
+- [ ] Check ADRs for relevant architectural decisions
+- [ ] Review framework best practices
+
+### 3. Plan (Goal: Implementation strategy)
+- [ ] List files to create/modify
+- [ ] Identify reusable components
+- [ ] Note dependencies or blockers
+- [ ] Estimate effort (compare to original story points)
+
+### 4. Implement (Goal: Working code)
+- [ ] Write tests first (TDD) or alongside code
+- [ ] Follow language standards (e.g., `code/python-standards.md`)
+- [ ] Keep commits logical and atomic
+- [ ] Run tests frequently
+
+### 5. Verify (Goal: Meets acceptance criteria)
+- [ ] All acceptance criteria met
+- [ ] Tests passing (unit, integration, e2e as needed)
+- [ ] Manual testing completed
+- [ ] Performance acceptable
+
+### 6. Document (Goal: Maintainable)
+- [ ] Add/update code comments for complex logic
+- [ ] Update README if user-facing changes
+- [ ] Create ADR if significant decision made
+
+### 7. Compound (Goal: Make next feature easier)
+- [ ] Complete retrospective
+- [ ] Update `/ai/learnings/` with insights
+- [ ] Note any standards improvements needed
+```
+
+### `/ai/workflows/code-review.md`
+```markdown
+## Code Review Workflow
+
+### Security Perspective
+- [ ] Input validation on all external data
+- [ ] Authentication/authorization checks present
+- [ ] No secrets in code or logs
+- [ ] SQL injection / XSS prevention
+
+### Performance Perspective
+- [ ] No N+1 queries
+- [ ] Database queries have appropriate indexes
+- [ ] Caching used where beneficial
+- [ ] No blocking operations in critical paths
+
+### Architecture Perspective
+- [ ] Follows established patterns
+- [ ] Appropriate abstraction level (not over/under-engineered)
+- [ ] Dependencies point in correct direction
+- [ ] No circular dependencies
+
+### Testing Perspective
+- [ ] Edge cases covered
+- [ ] Error paths tested
+- [ ] Test quality (not just coverage)
+- [ ] Integration tests for external dependencies
+
+### Standards Compliance
+- [ ] Follows language standards
+- [ ] Commit messages follow conventions
+- [ ] PR description complete
+- [ ] Documentation updated
+```
+
+**Impact**: Consistent, thorough approach to common tasks. Less reinvention, fewer missed steps, better quality.
+
+**Effort**: ~2 hours to create initial 3 workflows
+
+---
+
+## Implementation Order
+
+1. **Start with #2 (Completion Criteria)** - 30 minutes, immediate clarity
+2. **Then #1 (Knowledge Compounding)** - 1 hour setup, start documenting learnings
+3. **Then #3 (Workflow Skills)** - 2 hours, practical tools ready to use
+
+**Total setup time**: ~3.5 hours
+**Ongoing time**: 10-15 min per task for retrospective/learnings
+
+---
+
+## Success Metrics
+
+After 1 month of using these enhancements:
+
+- ✅ At least 3 learning documents exist with real insights
+- ✅ Completed tasks consistently meet all completion criteria
+- ✅ Workflow skills are referenced when doing relevant tasks
+- ✅ Agents ask fewer clarification questions
+- ✅ Similar tasks are completed faster than initial implementation
+
+---
+
+## References
+
+- [Adoption Roadmap](./adoption-roadmap.md) - Full phased plan with all enhancements
+- [Agent-Native Improvements](./agent-native-improvements.md) - Complete analysis of agent-native principles
+- [Compound Engineering Plugin](https://github.com/EveryInc/compound-engineering-plugin)
+- [Every.to Agent-Native Guide](https://every.to/guides/agent-native)

--- a/archive/top-3-enhancements.md
+++ b/archive/top-3-enhancements.md
@@ -2,7 +2,7 @@
 
 > **Implementation strategy superseded by [ADR-0001: Six-Layer AI Architecture](../docs/engineering/adr/0001-six-layer-ai-architecture.md).**
 >
-> This document analyzed agent-native principles and proposed building those abstractions in this repository. We instead adopted the six-layer AI architecture (see [ADR-0001](../docs/engineering/adr/0001-six-layer-ai-architecture.md)) with [compound-engineering](https://github.com/EveryInc/compound-engineering-plugin) as the canonical realization of Layers 2 and 3. Kept here as the evaluative framework that informed the architecture — the analysis remains the lens for re-evaluating CE adoption if circumstances change. See [`process/compound-engineering-integration.md`](../process/compound-engineering-integration.md) for the operational doc.
+> This document analyzed agent-native principles and proposed building those abstractions in this repository. We instead adopted the six-layer AI architecture (see [ADR-0001](../docs/engineering/adr/0001-six-layer-ai-architecture.md)) with [compound-engineering](https://github.com/EveryInc/compound-engineering-plugin) as the canonical realization of Layers 2 (Workflow Skills), 3 (Persona Agents), 4 (References), and 5 (Compound / Learnings). Kept here as the evaluative framework that informed the architecture — the analysis remains the lens for re-evaluating CE adoption if circumstances change. See [`process/compound-engineering-integration.md`](../process/compound-engineering-integration.md) for the operational doc.
 
 **Date**: 2026-01-24
 **Status**: Approved for Implementation

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,10 @@
+# Documentation
+
+This directory holds repository documentation per [`process/documentation-standards.md`](../process/documentation-standards.md).
+
+## Contents
+
+- **[`engineering/`](./engineering/)** — Architecture decision records, technical design documents
+- **[`plans/`](./plans/)** — Implementation plans (compound-engineering `ce-plan` outputs)
+
+Other top-level subdirectories (`product/`, `operations/`, `architecture/`) may be added when the relevant content exists. See `process/documentation-standards.md` for the full directory taxonomy.

--- a/docs/engineering/README.md
+++ b/docs/engineering/README.md
@@ -1,0 +1,9 @@
+# Engineering Documentation
+
+Technical documentation for the engineering-standards repository.
+
+## Contents
+
+- **[`adr/`](./adr/)** — Architecture decision records, numbered sequentially (e.g., `0001-<title>.md`)
+
+Future subdirectories may include `designs/` (technical design documents), `api/` (API schemas), or others as content emerges. See `process/documentation-standards.md` for the canonical directory taxonomy.

--- a/docs/engineering/adr/0001-six-layer-ai-architecture.md
+++ b/docs/engineering/adr/0001-six-layer-ai-architecture.md
@@ -1,0 +1,100 @@
+# ADR-0001: Six-Layer AI Architecture
+
+**Date:** 2026-05-03
+**Status:** Accepted
+
+## Decision
+
+This repository adopts a **six-layer AI architecture** as the conceptual model for AI tooling integrated with software engineering workflows. The architecture is the abstraction; specific implementations — most concretely [compound-engineering](https://github.com/EveryInc/compound-engineering-plugin) (CE) for [Claude Code](https://claude.ai/code) — fill the layers as canonical realizations. Vendor-neutral baselines remain in place for projects that do not adopt a specific toolkit; the layering itself preserves vendor-neutrality.
+
+## Context
+
+This repository previously documented a four-layer AI architecture (Rules / Skills / Agents / Hooks) introduced via PRs [#16](https://github.com/rmorison/engineering-standards/issues/16), [#19](https://github.com/rmorison/engineering-standards/issues/19), and [#21](https://github.com/rmorison/engineering-standards/issues/21). The four-layer model was a useful first sketch grounded in a thin, vendor-neutral toolkit (web-fetch-based skills and a small set of agents).
+
+Active use of compound-engineering across `rmorison` projects revealed that the four-layer model — taken literally — does not accommodate a developed LLM-engineering system without distortion. Three structural patterns visible in CE are absent from the original taxonomy:
+
+1. **Skill-orchestrated personas.** CE persona reviewers are prompt templates dispatched by orchestrator skills (`ce-doc-review`, `ce-code-review`); they are not standalone subagents in the original Layer 3 sense.
+2. **Skill-loaded reference subtrees.** CE skills ship `references/*.md` directories that progressively load context during workflow execution — neither at session start nor at invocation, but as workflow depth grows.
+3. **Compound / learnings.** CE captures institutional knowledge through `ce-compound`, `ce-compound-refresh`, and the `docs/solutions/` artifact pattern — a feedback loop that lets work compound rather than restart from blank.
+
+The right move is not to absorb CE's idiosyncrasies into the existing layers (which led to category errors during prior planning) and not to displace the four-layer wholesale (which loses the principle the original captured). The right move is to **evolve the architecture itself** to absorb the patterns CE has surfaced — keeping the abstraction general enough that other LLM-engineering toolkits, present or future, can fit the same slots.
+
+## The Architecture
+
+Each layer specializes a distinct **principle** for how AI capability composes with engineering work. The six principles together capture what makes LLM-based engineering function in practice today.
+
+| # | Layer | Principle | Vendor-neutral baseline | Canonical realization (CE) |
+|---|-------|-----------|-------------------------|----------------------------|
+| **1** | Rules | **Persistence** — load once per session, every session | `ai/claude-code/rules/*.md` (this repo) | Not provided by CE; standards repo retains ownership |
+| **2** | Workflow Skills | **Composability** — multi-step orchestrators that compose into pipelines | `templates/.claude/skills/{spec,plan,review}/` (this repo) | CE skills: `/ce-brainstorm`, `/ce-plan`, `/ce-work`, `/ce-doc-review`, `/ce-code-review`, `/ce-debug`, `/ce-compound`, `lfg`, … |
+| **3** | Persona Agents | **Perspective** — multiple expertises analyze the same artifact | `templates/.claude/agents/{code-reviewer,spec-writer}.md` (this repo) | ~20 CE persona reviewers (coherence, feasibility, adversarial, security, scope-guardian, language-specific style enforcers, …) |
+| **4** | References | **Progressivity** — context grows as workflow depth grows | (no vendor-neutral baseline yet) | CE skills' `references/*.md` subtrees, loaded during skill execution |
+| **5** | Compound / Learnings | **Compounding** — institutional knowledge accumulates across work | (no vendor-neutral baseline yet) | `docs/solutions/` populated by `ce-compound` and `ce-compound-refresh` |
+| **6** | Hooks | **Determinism** — non-AI enforcement at zero context cost | `templates/.claude/hooks/` (this repo) | Not provided by CE; standards repo retains ownership |
+
+### Layer descriptions
+
+**Layer 1 — Rules.** Compact pointers and behavioral guardrails kept in agent context every turn. Files in this layer load at session start and remain visible across all work; their discipline is to stay *small* (under ~150 lines each) so that the always-loaded budget stays affordable. Layer 1 typically directs the agent to the rest of the architecture rather than encoding policy inline.
+
+**Layer 2 — Workflow Skills.** Multi-step orchestrators invoked on demand by user or orchestrator. Skills compose into pipelines: discovery → planning → execution → review → compounding. A Layer 2 skill is *lazy-loaded* (its content enters context only when invoked), but implementations vary in depth: a vendor-neutral skill may be a thin URL-fetch template; a deeper realization may run multi-round workflows that dispatch Layer 3 personas and load Layer 4 references during execution.
+
+**Layer 3 — Persona Agents.** Specialized prompt templates that encode focused domain expertise (security, performance, coherence, framework-specific style, etc.). Persona Agents are typically **dispatched by Layer 2 skills** rather than invoked directly, though simple realizations may include standalone-invocable agents. The pattern of "one skill orchestrates many persona agents in parallel" is what makes multi-perspective review tractable.
+
+**Layer 4 — References.** Documents *loaded by skills during execution* — not at session start (Layer 1), not at invocation (Layer 2's initial bundle), but as workflow depth grows. References allow a Layer 2 skill to remain lean at the entry point while still being able to reach for deeper context when a particular workflow branch demands it. The vendor-neutral baseline for this layer is empty today; the pattern was surfaced by CE.
+
+**Layer 5 — Compound / Learnings.** Outcomes captured from completed work that feed forward into future work — closing the loop between execution and accumulated knowledge. Layer 5 artifacts include solution documents, retrospective notes, and post-mortem records. The principle is that work *compounds*: the second similar task should be cheaper and higher-quality than the first because the first's learnings are captured and findable.
+
+**Layer 6 — Hooks.** Shell-level scripts that run on tool-use events (pre/post invocation), enforcing rules deterministically and without consuming AI context. Layer 6 catches mechanical mistakes (typos in file paths, write attempts to protected paths, missing pre-commit checks) at zero AI cost.
+
+### How the layers compose
+
+Layers are independent slots: a project can fill some and leave others empty. A typical CE-using project fills all six. A minimal project might fill only Layers 1, 2, and 6.
+
+Pipelines are composed at Layer 2: a sequence of skill invocations (e.g., `ce-brainstorm → ce-plan → ce-work → ce-doc-review → ce-code-review → ce-compound`) carries an artifact from discovery to compound output. Each Layer 2 skill in the pipeline may dispatch Layer 3 personas (for review-shaped skills), load Layer 4 references (as workflow depth grows), and produce Layer 5 compound output (as learnings worth preserving). Layer 1 rules direct default behavior across all of the above; Layer 6 hooks enforce mechanical invariants at the shell boundary.
+
+## Why compound-engineering as canonical realization
+
+This ADR names CE specifically because:
+
+- CE is the most developed LLM-engineering implementation in active use across `rmorison` projects, with deep realizations of Layers 2 (~30 skills), 3 (~20 personas), 4 (skill reference subtrees), and 5 (compound + solutions).
+- Describing the architecture in CE's terms gives concrete grounding for adopters, while the layer definitions stay abstract enough that other realizations (Cursor commands, Aider, hand-rolled implementations) fit the same slots without contradiction.
+- CE is actively maintained at v3.x and follows a release cadence the architecture description can track.
+
+This is not exclusive: the architecture is intentionally vendor-neutral. Adopters can fill Layers 2–5 with a different toolkit, with hand-rolled implementations, or with the vendor-neutral baselines this repository provides. CE is named as canonical because it exists, works, and is in use — not because it is mandatory.
+
+**Upgrade discipline.** Pin to CE 3.x. Re-evaluate the integration at CE 4.x major version. Within 3.x, skill-name churn is a one-row change in the cross-reference table maintained by [`process/compound-engineering-integration.md`](../../../process/compound-engineering-integration.md).
+
+## Consequences
+
+**What changes:**
+
+- The architecture description names six layers (was four), with **References** (Layer 4) and **Compound / Learnings** (Layer 5) promoted to first-class layers.
+- Layer 2 (Workflow Skills) and Layer 3 (Persona Agents) acknowledge depth and orchestration variation: vendor-neutral baselines are thin and standalone; canonical realizations may be deeper and skill-orchestrated. Both fit the layer.
+- Solo / AI-driven workflows become a first-class scale alongside team-scale assumptions in existing standards.
+- AI-review (`ce-code-review` + `ce-doc-review`) is documented as **review discipline**, not an enforced merge gate. There is no CI check or branch-protection rule that enforces it. The discipline is process-level; failure modes are named explicitly in the integration doc so adopters know what they are trading.
+- An artifact-path precedence rule with a provenance clause governs the boundary between standards-mode and CE-mode paths.
+
+**What stays unchanged:**
+
+- ADR location and format (this very document follows the conventions in `process/documentation-standards.md`).
+- Semantic versioning, conventional commits, PR-based merges, GitHub Flow.
+- Code quality principles in `code/`.
+- The four-layer model's stated principle — *"Context is expensive — only load what's needed, when it's needed"* — is preserved and extended. Six layers, six specializations of context-cost discipline.
+- The vendor-neutral baselines (`templates/.claude/skills/`, `templates/.claude/agents/`, `templates/.claude/hooks/`, `ai/claude-code/rules/`) remain in place. They are not deprecated; they fill the layers for projects that do not adopt a deeper toolkit.
+
+**Maintenance liability:**
+
+- Naming a canonical realization (CE) creates a tracking obligation against an upstream this repository does not control. The integration doc describes CE skill behavior alongside skill names so name-churn within 3.x is a one-row table edit; major version transitions warrant a re-evaluation of the canonical-realization claim.
+- Layer 4 (References) and Layer 5 (Compound) currently have only a CE realization. The architecture describes what those layers are *structurally*; vendor-neutral realizations may emerge over time and would fit the same slots.
+
+## References
+
+- **Origin issue:** [rmorison/engineering-standards#22 (rescoped)](https://github.com/rmorison/engineering-standards/issues/22)
+- **Built on:** PRs [#16](https://github.com/rmorison/engineering-standards/issues/16), [#19](https://github.com/rmorison/engineering-standards/issues/19), [#21](https://github.com/rmorison/engineering-standards/issues/21) — the original four-layer architecture this work refines.
+- **Related issue:** [#12](https://github.com/rmorison/engineering-standards/issues/12) (Phase 0 — partially addressed by the integration doc's `docs/brainstorms/` declaration for CE-using projects).
+- **Operational reference:** [`process/compound-engineering-integration.md`](../../../process/compound-engineering-integration.md) — describes CE's realization of each layer plus path mappings, branch-naming reconciliation, AI-review discipline, and ticket-tracking modes.
+- **Architectural reference:** [`ai/claude-code/README.md`](../../../ai/claude-code/README.md) — canonical layer-by-layer description.
+- **Compound-engineering plugin:** https://github.com/EveryInc/compound-engineering-plugin (v3.1.0).
+- **Agent-native foundation:** https://every.to/guides/agent-native — the conceptual antecedent that informed both the four-layer model and CE.
+- **Archived prior proposals:** [`archive/`](../../../archive/) — three earlier `ai/*.md` documents that proposed building agent-native abstractions in this repository rather than adopting an existing toolkit. Preserved as the evaluative framework that informed this decision.
+- **Real-world deployment example:** `books-ops` (private rmorison repository) — informed the integration doc's wording during real use of the brainstorm → plan → ce-doc-review → lfg pipeline. Named as deployment context, not as a documentation reference.

--- a/docs/plans/2026-05-03-001-feat-compound-engineering-integration-plan.md
+++ b/docs/plans/2026-05-03-001-feat-compound-engineering-integration-plan.md
@@ -1,0 +1,556 @@
+---
+title: "feat: Integrate compound-engineering practices with the standards repo"
+type: feat
+status: abandoned
+date: 2026-05-03
+deepened: 2026-05-03
+abandoned: 2026-05-03
+origin: https://github.com/rmorison/engineering-standards/issues/22
+---
+
+> **Status: abandoned.** This plan iterated three rounds of multi-persona doc-review under shifting architectural framings:
+> 1. **Round 1**: "supersede the 4-layer with CE" — surfaced books-ops privacy, AI-review-as-gate overclaim, vendor coupling concerns.
+> 2. **Round 2**: "CE as specialization of Layers 2 and 3" — surfaced that CE doesn't fit the 4-layer cleanly (personas aren't standalone agents; depth gap is 10x; Layer 1 inlining violates compact-pointer purpose).
+> 3. **Round 3**: "morph the 4-layer to fit CE" — at this point the work had grown beyond CE integration into **architectural redesign with publishable framing**. The plan was no longer right-sized for what's actually being built.
+>
+> **Superseded by**: a fresh plan around the **6-layer AI architecture** (Rules / Workflow Skills / Persona Agents / References / Compound / Hooks) with CE as the canonical realization. The new plan frames the architecture as the abstraction and CE as one (highly developed) realization — supports the user's potential technical article *"Abstracting the Every Compound Engineering Model for LLM Based Engineering"* and the repo's encompassing-standard direction.
+>
+> Preserved here as iteration history: the operational findings (path mappings, branch-naming reconciliation, AI-review-as-discipline framing, books-ops privacy resolution by inlining, archive-prior-proposals-to-top-level) remain valid input to the new plan; the architectural framing was wrong, the operational details were right.
+
+# feat: Integrate compound-engineering practices with the standards repo (abandoned)
+
+## Overview
+
+Make the relationship between this repo's engineering standards and the compound-engineering (CE) plugin explicit by **framing CE as a specialization of Layers 2 (Skills) and 3 (Agents)** of the 4-layer AI architecture this repo already ships (PRs #16/#19/#21). The 4-layer model is the abstraction: it defines four context-cost slots (Rules / Skills / Agents / Hooks) for AI tooling. CE is a deep, vendor-coupled implementation of two of those slots that you load when you install the plugin. The vendor-neutral `templates/.claude/skills/{spec,plan,review}/` and `templates/.claude/agents/` remain in place as the Layer 2/3 baseline for projects that don't run CE.
+
+This framing — **abstraction (the 4-layer model) + specialization (CE as the deep implementation of Layers 2 and 3 when present)** — is load-bearing for the integration. The top-level docs (`README.md`, `ai/CLAUDE.md`, `ai/claude-code/README.md`) explicitly stress this layering so new adopters understand the architecture before any specific workflow.
+
+The plan delivers: an ADR establishing the layering, a process doc that inlines its own load-bearing content (so a public reader can apply it without 404'ing on a private books-ops link), inline-replace fixes for conflicting *content* in `ai/CLAUDE.md` and `ai/claude-code/rules/` (the always-loaded Layer 1 files), archival of three prior agent-native proposals to top-level `archive/`, a CE-as-specialization subsection added to README and `ai/claude-code/README.md`, a CE-aware section in `templates/CLAUDE.md`, and cross-references in the five existing process docs. Solo / AI-driven workflows become a first-class scale alongside the team-scale assumptions that pervade the current standards.
+
+**Critically, the lightweight skills (`/spec`, `/plan`, `/review`) and agents (`code-reviewer`, `spec-writer`) are NOT archived** — they are the vendor-neutral baseline of Layers 2 and 3. CE specializes those layers when installed; both remain available, with CE-using projects defaulting to the deeper CE skills.
+
+The key precedence rule the integration doc enforces: **when a CE skill produces an artifact, CE paths and conventions win; standards paths and conventions still own human-authored artifacts and ADRs.** Provenance edge cases (co-authored docs, human-bootstrapped artifacts later run through a CE skill, CE outputs later edited by hand) are resolved by a "first-skill-touched-the-file" rule, with an escape hatch for explicit reclassification — see Key Technical Decisions.
+
+A second, deliberately humbler framing: the AI-review process described here is **review discipline, not an enforced merge gate**. The repo has no CI check or branch-protection automation that can enforce "no unresolved P0/P1 findings." Adopters get value by following the discipline; they don't get a wall.
+
+---
+
+## Problem Frame
+
+Both systems ship in the same repos today (e.g., `books-ops`) with no documented relationship:
+
+- Standards prescribe `docs/product/`, `docs/engineering/designs/`, `docs/engineering/adr/`, `docs/planning/`. CE writes to `docs/ideation/`, `docs/brainstorms/`, `docs/plans/`, `docs/solutions/`. Direct path conflict at `docs/plans/` vs `docs/planning/`. No standards analog for `docs/solutions/`.
+- Standards' three-tier issue hierarchy (Milestone → Epic → Implementation) is right for 3-5-person teams. CE plan files use U-IDs as the unit tracker; pre-allocating sub-issues per U duplicates state and drifts from the plan. Standards already have implicit solo carve-outs (`process/issue-tracking.md`'s "<3 issues: just use labels" / "<1 month: might not need epic structure") but they aren't surfaced.
+- Standards' branch naming (`{issue-number}-{slugified-title}`) directly contradicts CE's `lfg` / `ce-work` autonomous flows that produce `feat/...` / `fix/...` branches without a parent issue. `process/git-branching-strategy.md`'s "❌ Branches Without Issues" anti-pattern needs a reframe, not just a pointer.
+- Branch protection in standards assumes "Require at least 1 approval." For solo CE work, the human reviewer slot is replaced by `ce-code-review` + `ce-doc-review` + PR self-review — but the criteria for "review passed" are undefined, and the substitution itself has unexamined failure modes (scope drift across PRs that AI reviewers don't see, self-grading loops, no second-pair-of-eyes with independent stakes).
+- `ai/CLAUDE.md` is the highest-leverage AI-facing artifact (agents read it every turn) and currently hardcodes the standards paths *and* the unqualified `{issue-number}-{slugified-title}` branch-naming rule that directly contradicts CE's `lfg` / `ce-work` flows. Side-by-side overrides leave conflicting top-of-file content; agents reading top-down hit standards rules before reaching the CE section. The fix needs to be inline replacement of conflicting rules, not addition.
+- Three untracked `ai/` proposals (`adoption-roadmap.md`, `agent-native-improvements.md`, `top-3-enhancements.md`) document a path-not-taken: building agent-native abstractions ourselves rather than adopting CE directly. They need clear supersession **and** physical relocation outside the agent-context tree (top-level `archive/`, not `ai/archive/`) so recursive agent globs and template-copying adopters don't ingest them.
+- **Newly merged into `main` (PRs #16, #19, #21) and discovered after initial planning**: a 4-layer AI architecture (Rules + Skills + Agents + Hooks) that — once correctly understood — does NOT compete with CE; it provides the taxonomy CE specializes. The 4-layer model defines four context-cost slots; CE is a deep implementation of two of them (Skills and Agents) that loads when the plugin is installed. The genuine integration tasks remaining are: (a) Layer 1 *content* conflicts — `ai/claude-code/rules/engineering-standards.md` hardcodes the standards-only `docs/` tree and unqualified branch-naming, and `ai/claude-code/rules/sdlc-workflow.md`'s "wait for explicit confirmation before proceeding" contradicts CE's `lfg` autonomous flow; the layer itself is correct, the content needs CE-aware updates; (b) Layer 2/3 default selection — adopters need to know which deep implementation fills Layers 2 and 3 (CE if installed, vendor-neutral templates otherwise); (c) discoverability — the README's "AI / Claude Code Integration" section currently describes the 4-layer model without naming CE as the specialization, so CE adopters don't see the relationship; (d) cross-references in the five existing process docs.
+
+The `books-ops` project ([private CLAUDE.md](https://github.com/rmorison/books-ops/blob/main/CLAUDE.md), inaccessible to non-rmorison readers) absorbed all five gaps locally during real use of the ideation → brainstorm → plan → ce-doc-review → lfg pipeline. Its absorbed wording is battle-tested. **Because `engineering-standards` is a public, copyable template repo, the integration doc inlines the load-bearing content (Documentation Paths table, Review Discipline paragraph, Ticket Policy block) directly rather than pointing readers at a 404.** books-ops is named as a real-world deployment example, not as a canonical reference.
+
+---
+
+## Requirements Trace
+
+- R1. Document the decision to integrate CE with the standards, with rationale and pointers (issue #22 acceptance criterion: ADR).
+- R2. Produce an integration process doc with five sections: artifact location mapping, issue-tracking modes, branch-naming reconciliation, solo-scale adaptations, CE skill ↔ standards doc cross-reference (issue #22 acceptance criterion).
+- R3. Add minimal cross-references to the five named existing process docs (issue #22 acceptance criterion).
+- R4. Reference at least one downstream project (`books-ops`) as the integration's working example (issue #22 acceptance criterion).
+- R5. Add no weakening of team-scale standards; the solo-mode track adds, never replaces (issue #22 acceptance criterion).
+- R6. Add `docs/solutions/` to the path mapping as a CE-owned path with no standards analog (Claude review gap #1; books-ops absorbed).
+- R7. Define the AI-review **discipline** (not enforced gate) — what `ce-code-review` + `ce-doc-review` checks, what failure modes the substitution invites, and explicitly state that the discipline is process-level, not enforced by repo configuration (Claude review gap #2; books-ops left undefined; doc-review surfaced enforcement and failure-mode gaps).
+- R8. Update `ai/CLAUDE.md` to **inline-replace the conflicting Quick Reference content** (workflow paths, branch-naming rule) for CE-mode and add the precedence section. Side-by-side override is rejected because it leaves contradictory standards-path content above the override (Claude review gap #3; books-ops absorbed locally; doc-review identified that side-by-side fails for agents reading top-down).
+- R9. Declare `docs/brainstorms/` (the `ce-brainstorm` output) as the Phase 0 / discovery artifact for `process/feature-development-workflow.md`, with Phase 1 seeded from it. Closes the overlap with issue #12 (Claude review gap #4; books-ops absorbed).
+- R10. Reframe `process/git-branching-strategy.md`'s "❌ Branches Without Issues" anti-pattern to allow topic-style naming for `lfg` / `ce-work` flows without a parent issue (Claude review gap #5; books-ops absorbed).
+- R11. Supersede the three prior `ai/` proposal docs by relocating them to top-level `archive/` (outside the agent-context `ai/` tree) and adding banners pointing at the new ADR. User selected archive-with-banner; doc-review surfaced that placing them under `ai/archive/` keeps them in agent-recursive globs and in the copyable template tree, which defeats the goal — so the location moves to top-level `archive/`.
+
+- R12. Defend the choice to couple the engineering standards to one specific AI-workflow plugin (CE/EveryInc) rather than describe vendor-neutral patterns. The ADR carries a "Why this plugin specifically" subsection that names the alternative considered (vendor-neutral patterns + CE as one realization), explains why direct adoption beats neutrality for the rmorison use case, and states the upgrade discipline relative to CE's release cadence (doc-review product-lens finding).
+
+- R13. Specify the precedence rule's behavior on edge-case provenance: co-authored documents, human-bootstrapped artifacts later run through a CE skill, CE outputs later edited by hand. Resolution: "first-skill-touched-the-file" rule with an explicit reclassification escape hatch (doc-review adversarial finding).
+
+- R14. Update the *content* of the Layer 1 always-loaded rules — `ai/claude-code/rules/engineering-standards.md` (hardcoded `docs/` tree, unqualified branch-naming) and `ai/claude-code/rules/sdlc-workflow.md` ("wait for confirmation before implementing" contradicts `lfg`) — to be CE-aware. The layer itself is correct; the content currently presupposes Layer-2-as-templates-only. Same two-mode pattern as `ai/CLAUDE.md` (R8): describe the standards-mode rule and the CE-mode addendum.
+
+- R15. **Establish the layering explicitly across top-level AI docs.** The 4-layer model is the abstraction; CE is the specialization of Layers 2 (Skills) and 3 (Agents) that loads when the plugin is installed. This is stated in: the ADR (U1), `ai/claude-code/README.md` (U3 — currently describes the 4-layer architecture; expand to name CE as the specialization for Layers 2 and 3), `ai/CLAUDE.md` (U3), and the README's "AI / Claude Code Integration" section (U7). Top-level docs are the new-adopter onboarding surface; the layering must be visible there.
+
+- R16. Add a CE-as-specialization subsection to the README's "AI / Claude Code Integration" section (lines 96–117). **Do NOT replace the 4-layer description** — it remains accurate for projects that don't run CE. Add a subsection naming CE as the deep implementation of Layers 2 and 3 when installed, with pointers to the ADR (U1) and integration doc (U2). Update Layer 2 and Layer 3 rows of the existing Layer table to note "(or CE skills/agents when CE is installed)".
+
+---
+
+## Scope Boundaries
+
+- Forking compound-engineering or maintaining its skill content here.
+- Tracking compound-engineering's version updates inside the standards (the integration doc describes CE-skill behavior and artifact shape, not specific skill names where possible — reduces maintenance churn per issue #22 technical notes).
+- Wholesale rewrite of existing standards docs.
+- Building automated tooling that enforces CE-mode vs standards-mode (no `.project-status.json`, no validation scripts, no JSON standards index — those were the path-not-taken in the now-archived `ai/` proposals).
+- Defining a deep AI-review scoring rubric beyond the merge-gate criteria (R7). Rubric refinement can be a follow-up if real use surfaces ambiguity.
+
+### Deferred to Follow-Up Work
+
+- Rewrite of `code/python-standards.md`, `code/database-standards.md`, `code/web-application-standards.md` to add CE-skill cross-references — these are language/stack standards, not process; they don't need the same touch-up. Surface in a follow-up issue only if real use shows a gap.
+- Hooks that enforce CE-mode invariants (e.g., a hook that warns if `/plan` is invoked instead of `/ce-plan` in a CE project). Not required for #22; the 4-layer's existing example hooks remain in place and could host this in a follow-up if adopters report confusion.
+- Project-specific wrapper skills (e.g., a `templates/.claude/skills/ce-plan-wrapper/` that pre-fills repo conventions before invoking `/ce-plan`). Adds vendor coupling at the template level; defer until concrete need.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- [`books-ops/CLAUDE.md`](https://github.com/rmorison/books-ops/blob/main/CLAUDE.md) — the canonical working example. Sections to lift: Documentation Paths table (lines 75–89), Review Gate paragraph (lines 48–49), Ticket Policy (lines 59–73), branch-naming carve-out (line 73). Adapt wording from books-ops-specific to integration-doc-generic.
+- `ai/CLAUDE.md` lines 22–66 — Quick Reference / Documentation Structure block that hardcodes the standards paths. The new "When using compound-engineering" section overrides this block.
+- `process/feature-development-workflow.md` lines 40–70 — Phase 1 (Product Concept) block (heading through the Example) is the seam where Phase 0 (CE brainstorm) attaches. The cross-ref note goes near the top of this Phase block.
+- `process/issue-tracking.md` lines 359–373 — already-existing solo carve-outs ("<3 issues: just use labels", "<1 month: might not need epic structure"). The integration doc cites these as the foundation for solo mode rather than inventing new ones.
+- `process/git-branching-strategy.md` lines 287–291 — the "❌ Branches Without Issues" anti-pattern that requires reframe (R10). Lines 322–331 — branch protection block where R7 merge-gate criteria attach.
+- `process/project-planning-standards.md` lines 79–86 — already has solo carve-out ("Individual contributors can estimate solo...") that the integration doc cites for R5 compliance.
+- `process/documentation-standards.md` lines 36–46 — `docs/planning/` is described as optional; the integration doc declares CE's `docs/plans/` as the CE-mode replacement.
+
+### Institutional Learnings
+
+- The three archived `ai/` proposals (`adoption-roadmap.md`, `agent-native-improvements.md`, `top-3-enhancements.md`) document the path-not-taken: building our own agent-native abstractions (workflows, learnings dirs, JSON indices, parity matrix). The decision to adopt CE directly supersedes these. Their analysis of agent-native principles remains valid — what changed is the implementation strategy. The archive banners (U4) preserve this context.
+- The `books-ops` integration was forced through the full pipeline (ideation → brainstorm → plan → ce-doc-review → lfg) and surfaced all five Claude-reviewer gaps in real use. Treating books-ops' absorbed wording as the source of truth is faster and lower-risk than re-deriving from first principles.
+
+### External References
+
+- [Compound Engineering Plugin](https://github.com/EveryInc/compound-engineering-plugin) — version 3.1.0 currently. The integration doc describes skill behavior and artifact shape, not exact names where possible (per issue #22 technical notes), to reduce churn.
+- [Every.to Agent-Native Guide](https://every.to/guides/agent-native) — the conceptual foundation; the archived `ai/` proposals analyzed it. The integration doc points to it as background reading, not as a competing framework.
+
+---
+
+## Key Technical Decisions
+
+- **CE precedence rule with provenance clause** (R13): when a CE skill produces an artifact, CE paths and conventions win; standards paths and conventions own human-authored artifacts and ADRs. Edge cases: (a) **first-skill-touched-the-file wins** — if `ce-plan` produced `docs/plans/foo.md`, subsequent human edits don't reclassify it as hand-authored; (b) **human-bootstrapped artifacts later run through a CE skill** become CE-mode at the skill's first touch; (c) **explicit reclassification** is allowed via a one-line frontmatter note (`provenance: hand-authored` or `provenance: ce-plan`) when the default rule produces the wrong answer. Rationale: forces a clean disambiguation that an agent can apply without re-deriving per project; the escape hatch handles the inevitable cases where heuristics fail.
+- **ADR location**: `docs/engineering/adr/0001-compound-engineering-integration.md`, not `process/adr/` as the issue body proposed. Aligns with what `ai/CLAUDE.md` and `process/documentation-standards.md` already reference. Creating `docs/engineering/adr/` is correct rather than papering over a pre-existing inconsistency. **Note** (doc-review finding): `process/documentation-standards.md` line 125 says "each `docs/` subdirectory should have a `README.md`." U1 also creates `docs/README.md` and `docs/engineering/README.md` to honor this — minimal stubs pointing into the actual content.
+- **`ai/CLAUDE.md` strategy — two-mode framing inline, anchored in the layering** (R8): the existing Quick Reference (Documentation Structure, Feature Development Workflow, branch-naming rule) is reframed as two-mode blocks. Each block names the vendor-neutral baseline (the existing rule, what loads when CE is not installed) and the CE-mode addendum (what changes when the CE plugin is in use). Both modes remain visible. Polarity rationale: the layering itself defines the default — Layer 2/3 baselines are the templates' vendor-neutral skills/agents; CE specializes those layers when installed. Agents read whichever applies to their environment without ambiguity.
+- **Disposition of prior `ai/` proposals — top-level `archive/`** (R11): relocate three untracked `ai/*.md` files (`adoption-roadmap.md`, `agent-native-improvements.md`, `top-3-enhancements.md`) to top-level `archive/`. These three documents are the genuine path-not-taken: they proposed building agent-native abstractions ourselves rather than adopting an existing toolkit. The 4-layer model that shipped via PRs #16/#19/#21 is **not** archived — it is the abstraction CE specializes. Top-level `archive/` (rather than `ai/archive/`) keeps the relocated files out of agent-recursive globs and out of the copyable `ai/` subtree.
+- **AI-review discipline (not enforced gate)** (R7): the integration doc names this as **review discipline** that adopters voluntarily follow, not a merge gate enforced by repo configuration. There is no CI check, branch-protection automation, or PR template that enforces "no unresolved P0/P1 findings" — claiming otherwise would be aspirational documentation. The discipline names: (a) `ce-code-review` on the diff; (b) `ce-doc-review` on the plan or spec when applicable; (c) self-review against plan acceptance criteria. **Under the layering, the CE persona reviewers ARE Layer 3** — `ce-code-review` and `ce-doc-review` are the deep specialization of Layer 3 that fires when CE is in use. The integration doc also names the failure modes the discipline does not catch: cross-PR scope drift (AI reviewers see a single diff), self-grading loops (the implementer decides what "unresolved" means in solo mode), product-positioning regressions (AI reviewers tuned for code patterns miss strategic intent). When a human reviewer onboards, the standards' "Require at least 1 approval" rule re-engages and AI review becomes complementary.
+- **Vendor coupling reframed under specialization** (R12): the ADR's defense of CE adoption is now framed as "CE is a deep, vendor-coupled specialization of Layers 2 and 3 that you load when you install the plugin." The vendor-neutral baseline (`templates/.claude/skills/`, `templates/.claude/agents/`) remains in place as the default for projects that don't run CE. This is materially different from "we picked CE over vendor-neutrality" — vendor-neutrality is preserved by the layering itself; vendor coupling lives in the specialization layer where adopters opt in by installing the plugin. **Upgrade discipline**: pin to CE 3.x; re-evaluate at CE 4.x major version. The integration doc describes skill behavior alongside skill names so name churn within 3.x is a one-row table edit.
+- **Phase 0 declaration**: `docs/brainstorms/` IS the Phase 0 / discovery artifact for the feature workflow **when CE is in use**. Phase 1 (Product Concept) is seeded from the brainstorm requirements doc. **Issue #12 framing** (revised after doc-review): #12 is "partially addressed" by R9, not "closed." Non-CE adopters still see Phase 1 starting cold; if #12's acceptance language requires Phase 0 for non-CE adopters too, that's a separate follow-up. Verify #12's actual acceptance criteria before closing.
+- **CE-skill name handling**: the integration doc uses skill names (`ce-brainstorm`, `ce-plan`, `ce-work`, `ce-code-review`, `ce-doc-review`, `lfg`) for the skill-↔-standards cross-reference table, but describes the behavior alongside each name. The names are stable in CE 3.x; if they change, only the table needs updating.
+- **Single PR scope** (revised after specialization-framing pass): the integration PR is ~400–500 lines / ~10–12 files after dropping R15 (the 4-layer skills and agents are not archived) and reducing R16 from rewrite to additive. This is close to `process/git-branching-strategy.md`'s 200-400-line target. The artifacts still cross-reference each other (ADR ↔ integration doc ↔ `ai/CLAUDE.md` ↔ `ai/claude-code/rules/` ↔ README), so single-PR scope stays the right call. If review surfaces clear seams (e.g., U1+U2 first, U3-U8 follow), the PR can be split — units are dependency-ordered.
+
+- **Layer architecture as the load-bearing framing** (new — supersedes the prior "supersede vs coexist" decision): the relationship between the 4-layer model and CE is not "CE replaces the 4-layer." It is "**the 4-layer is the abstraction; CE is the deep specialization of Layers 2 and 3 that loads when the plugin is installed.**" The 4-layer's vendor-neutral skills (`templates/.claude/skills/{spec,plan,review}/`) and agents (`templates/.claude/agents/`) remain in place as the Layer 2/3 baseline. CE skills (`/ce-brainstorm`, `/ce-plan`, `/ce-work`, `/ce-code-review`, `/ce-doc-review`, `lfg`, etc.) and CE persona reviewers fill the same layers more deeply for projects that have CE installed. **The 4-layer principle — "Context is expensive — only load what's needed, when it's needed" — is exactly CE's design philosophy; CE embodies the principle more deeply than the 4-layer's own thin skills did.** This framing is load-bearing: it preserves vendor-neutrality (the layering itself), makes CE adoption purely additive (no architecture is being superseded), and dramatically reduces PR scope. New-adopter onboarding docs (`README.md`, `ai/CLAUDE.md`, `ai/claude-code/README.md`) explicitly state this layering — the user-stated requirement is "make sure top-level docs stress this" because the layering is what facilitates architecture and understanding for adopters who land on the repo cold.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- ADR location → `docs/engineering/adr/` (user answer; aligns with documentation-standards.md).
+- Disposition of prior `ai/` proposals → top-level `archive/` (revised from initial `ai/archive/` answer; doc-review surfaced that placement under `ai/` keeps them in agent-recursive globs and template trees).
+- `ai/CLAUDE.md` strategy → inline section (user answer).
+
+### Deferred to Implementation
+
+- Exact wording of the "Implementation strategy superseded by ADR-0001" banner — finalize in U4 against the ADR's actual frontmatter title.
+- Whether `process/documentation-standards.md` needs an Optional Directory entry for `docs/brainstorms/` / `docs/ideation/` / `docs/plans/` / `docs/solutions/`, or whether the integration doc's path mapping is enough. Default to a single cross-ref; revisit only if the standards' Optional Directories list (lines 28–47) feels misleading without it.
+- Whether `archive/README.md` is needed (default: skip, since the three superseded banners + the U7 README mention are sufficient discovery). Revisit if a reader genuinely benefits from the directory-level explainer.
+
+### From 2026-05-03 doc-review (deferred)
+
+- **Issue #12 closure framing**: R9 adds a CE-conditional Phase 0 cross-ref to `process/feature-development-workflow.md`, not a Phase 0 spec for non-CE adopters. Verify #12's actual acceptance language before closing — if it requires Phase 0 for all adopters, this plan only partially addresses it and #12 stays open.
+- **Solo + AI as first-class scale: audience-segmentation cost** — every standards doc now requires routing logic ("which mode am I in?") before the rule applies. The product-lens reviewer flagged this as an unexamined cumulative readability tax. Lighter alternative: keep team-mode as the spine, put CE/solo content in a single annex doc, minimize cross-refs from standards docs back into it. Worth re-evaluating after the integration ships and adopters have read the new structure.
+- **U7 (README update) scope**: scope-guardian and adversarial reviewers flagged this as not in issue #22's acceptance criteria and possibly speculative. Default: keep U7 (small, surfaces integration from front door, justifies its own ≤4 lines). Drop only if it creates real tension with discovery via `ai/CLAUDE.md` Quick Links.
+- **`ce-compound`, `ce-compound-refresh`, `ce-debug` table entries**: U2's skill cross-reference table should explicitly state that these are meta-skills with no artifact-path output (verified via `ls ~/.claude/plugins/.../compound-engineering/3.1.0/skills/`). Avoid the table reading as half-filled.
+- **Standards-side conflict resolution**: the precedence rule says "CE wins when CE produces the artifact" — but what about the inverse? If CE produces an artifact whose conventions conflict with a standards principle (e.g., a future CE skill that emits a non-Fibonacci estimation field), is the rule still "CE wins"? Adversarial reviewer flagged this as asymmetric. Likely answer: the rule is path/format precedence, not principle precedence — standards principles still apply within CE-produced artifacts. Capture in the integration doc only if real use surfaces a conflict.
+- **Recursive-glob safety for `ai/`**: U4 moves archives to top-level `archive/`. Worth checking whether any other files in `ai/` (e.g., the original `ai/CLAUDE.md`) get loaded as policy by tools beyond Claude Code. Out of scope for this plan; flag if discovered during U3 implementation.
+
+---
+
+## Implementation Units
+
+- U1. **ADR — Adopt compound-engineering as the AI workflow standard**
+
+**Goal:** Capture the decision to integrate CE with the engineering standards by **framing CE as a deep specialization of Layers 2 and 3** of the 4-layer AI architecture this repo already ships. State the layering explicitly so future readers see the architectural relationship without re-deriving it. Defend the choice to load CE as the Layer 2/3 specialization for rmorison projects (rather than building the depth ourselves), and point to U2 for operational details.
+
+**Requirements:** R1, R5, R12, R15
+
+**Dependencies:** None.
+
+**Files:**
+- Create: `docs/README.md` (one-paragraph stub: "this directory holds documentation per `process/documentation-standards.md`; current contents: `engineering/adr/`, `plans/`")
+- Create: `docs/engineering/README.md` (one-paragraph stub pointing into `adr/` with a note that `designs/` would live here too when written)
+- Create: `docs/engineering/adr/0001-compound-engineering-integration.md`
+
+**Approach:**
+- Create the directory tree (`docs/`, `docs/engineering/`, `docs/engineering/adr/`). `docs/plans/` already exists (this plan lives there).
+- Create the two README stubs to honor `process/documentation-standards.md` line 125.
+- Use the lightweight ADR format described in `process/documentation-standards.md` (Decision / Context / Consequences / References). Keep it ≤2 pages.
+- **Decision**: adopt compound-engineering (CE) v3.1.0+ as the deep specialization of Layers 2 (Skills) and 3 (Agents) of this repo's 4-layer AI architecture. State the layering explicitly: the 4-layer model is the abstraction; CE fills Layers 2 and 3 with deep, vendor-coupled implementations when the plugin is installed. The vendor-neutral baseline (`templates/.claude/skills/`, `templates/.claude/agents/`) remains the default for projects without CE. Layer 1 (Rules) and Layer 4 (Hooks) are unchanged; their content is updated to be CE-aware where it conflicts (R14).
+- **Context**: PRs #16/#19/#21 (~5 weeks ago) shipped the 4-layer model. CE is in active use across `rmorison` projects (most concretely `books-ops`). The relationship between the two has been re-derived per project. This ADR establishes the architectural layering that resolves the re-derivation tax.
+- **The layering — Why this framing (R15)**: subsection establishing the 4-layer abstraction + CE specialization explicitly. Layer 1 (Rules) holds always-loaded session context; Layer 2 (Skills) is on-demand workflows; Layer 3 (Agents) is specialized subagents; Layer 4 (Hooks) is deterministic shell-level enforcement. CE provides Layer 2 and Layer 3 implementations that are deeper than the templates' vendor-neutral defaults (~30 skills vs 3, ~20 persona reviewers vs 2). CE doesn't ship Layer 1 or Layer 4 content; those continue to come from this repo. The 4-layer principle ("context is expensive — only load what's needed, when it's needed") is exactly CE's design philosophy; CE embodies it more deeply than the 4-layer's own thin skills did.
+- **Why CE rather than building the depth ourselves (R12)**: subsection defending the choice to install CE as the Layer 2/3 specialization rather than expanding the vendor-neutral skills toward CE-level depth. Alternative considered: build deeper Layer 2 and Layer 3 implementations in `templates/.claude/skills/` and `templates/.claude/agents/`, vendor-neutral. Rejected because (a) CE already provides this depth and is actively maintained, (b) duplicating it would be a maintenance liability against an evolving target, (c) the layering preserves vendor-neutrality at the 4-layer's own depth — adopters who don't run CE retain a working baseline. **Upgrade discipline**: pin to CE 3.x; re-evaluate at 4.x.
+- **Consequences**: list what changes (Layer 2/3 default-when-CE-installed, solo-mode is first-class, AI-review **discipline** — not enforced gate, precedence rule with provenance clause for artifact paths), what stays unchanged (ADR location, semver, conventional commits, PR-based merges, code quality principles, the 4-layer model itself, the vendor-neutral templates), and explicitly note the maintenance liability the vendor coupling creates at the specialization layer.
+- **References**: issue #22, the integration doc (U2), PRs #16/#19/#21 (the 4-layer model — referenced as foundational, not superseded), the three archived `ai/*.md` proposals (superseded — they proposed building agent-native abstractions ourselves rather than using the 4-layer + CE specialization framing), and books-ops as a real-world deployment example (qualified: "private repo, named for context not as a reference").
+- Number 0001 since no ADRs exist yet in this repo.
+
+**Patterns to follow:**
+- ADR shape from `process/documentation-standards.md` lines 83–92.
+
+**Test scenarios:**
+- Test expectation: none — documentation change. Verification is structural review per the next field.
+
+**Verification:**
+- ADR exists at `docs/engineering/adr/0001-compound-engineering-integration.md`.
+- `docs/README.md` and `docs/engineering/README.md` exist as minimal stubs.
+- Sections present: Decision / Context / The layering — Why this framing / Why CE rather than building the depth ourselves / Consequences / References.
+- The layering subsection explicitly names the 4-layer model (with all four layers) and identifies CE as the deep specialization of Layers 2 and 3.
+- Precedence rule with provenance clause stated unambiguously for artifact paths.
+- Consequences explicitly distinguish "review discipline" from "enforced merge gate."
+- The 4-layer's principle ("context is expensive — only load what's needed") is restated and credited as CE's design philosophy too.
+- Pointer to `process/compound-engineering-integration.md` (U2) is present.
+- References include issue #22, PRs #16/#19/#21 (foundational, not superseded), the three archived prior proposals, and books-ops qualified as real-world deployment, not canonical reference.
+
+---
+
+- U2. **Process doc — compound-engineering integration (self-contained, not pointer-only)**
+
+**Goal:** Operational reference that resolves the path conflicts, ceremony scaling, branch-naming reconciliation, and AI-review discipline. **The doc is self-contained**: it inlines the load-bearing tables and paragraphs (Documentation Paths, Review Discipline, Ticket Policy) directly so a public reader without rmorison access can apply it without 404ing on books-ops links.
+
+**Requirements:** R2, R4, R5, R6, R7, R12, R13
+
+**Dependencies:** U1 (the doc references the ADR by number).
+
+**Files:**
+- Create: `process/compound-engineering-integration.md`
+
+**Approach:**
+- Header section: scope statement, audience ("projects using compound-engineering — most concretely the `rmorison` projects, but the integration is intended to be readable and usable by any adopter"), and the precedence rule with provenance clause (R13).
+- Five sections per issue #22:
+  1. **Artifact location mapping** — full table including `docs/solutions/` row (R6). Inline the table content directly into the integration doc (do not point at books-ops). State the precedence rule and the provenance clause (first-skill-touched-the-file; explicit `provenance:` frontmatter override). Sample row format mirrors books-ops' battle-tested table:
+
+     | Path | Owner | Producer |
+     | --- | --- | --- |
+     | `docs/ideation/` | CE | `ce-ideate` |
+     | `docs/brainstorms/` | CE | `ce-brainstorm` — also serves as Phase 0 / discovery artifact for `process/feature-development-workflow.md`; Phase 1 is seeded from the brainstorm |
+     | `docs/plans/` | CE | `ce-plan` (subsumes `docs/planning/` from the standards) |
+     | `docs/solutions/` | CE | `ce-compound`, `ce-compound-refresh` (no standards analog) |
+     | `docs/engineering/adr/` | shared | human-authored ADRs (path identical in both models) |
+     | `docs/engineering/designs/` | standards | human-authored design docs |
+     | `docs/product/` | standards | human-authored product concepts and feature specs |
+
+  2. **Issue-tracking modes** — three modes: team-scale (full three-tier hierarchy from `process/issue-tracking.md`), solo + AI (reactive issue creation, plan U-IDs as unit tracker), hybrid (solo today, team tomorrow — adopt lean now, add epics/milestones when a second contributor arrives). Cite the existing solo carve-outs in `process/issue-tracking.md` lines 359–373 ("<3 issues: just use labels", "<1 month: might not need epic structure") as the foundation rather than inventing new ones. Inline a minimal Ticket Policy block (umbrella epic per multi-phase plan, sub-issues reactive, U-aligned branch naming) so adopters do not need to read books-ops to see the pattern.
+
+  3. **Branch-naming reconciliation** — issue-numbered when an issue exists, topic-style (`feat/...`, `fix/...`) when produced by `lfg` / `ce-work` without a parent issue. Standards' rule applies once an issue is opened. State that this works in concert with U5's anti-pattern reframe.
+
+  4. **Solo-scale adaptations + AI-review discipline** — what shifts at solo scale: no planning poker (point estimates become self-calibration; cite `process/project-planning-standards.md` line 86), no human code-review assignment (replaced by AI-review **discipline**, definition follows), milestones earn their keep at >3-month horizons, epic structure earns its keep at 5+ implementation issues per feature.
+     - **AI-review discipline (R7, revised)**: a sub-block stating clearly: **this is review discipline, not an enforced merge gate.** No CI check, no branch-protection automation, no PR template enforces it — claiming otherwise would be aspirational documentation. The discipline names: (a) `ce-code-review` on the diff before merge; (b) `ce-doc-review` on the plan or spec when applicable; (c) self-review against plan acceptance criteria.
+     - **Failure modes the discipline does not catch** (named explicitly so adopters can compensate): cross-PR scope drift (AI reviewers see one diff at a time and rarely flag missing requirements that span PRs); self-grading loops (in solo mode the implementer decides what "unresolved" means); product-positioning regressions (AI reviewers tuned for code patterns miss strategic intent); same-intent author-and-reviewer collapse (no second pair of eyes with independent stakes).
+     - When a human reviewer onboards, the standards' "Require at least 1 approval" rule re-engages and AI-review becomes complementary.
+
+  5. **Compound-engineering skill ↔ standards doc cross-reference** — table mapping CE skills (`ce-brainstorm`, `ce-plan`, `ce-work`, `ce-code-review`, `ce-doc-review`, `lfg`, `ce-compound`, `ce-compound-refresh`, `ce-debug`) to the standards docs they operate within. **Each row describes behavior alongside the skill name** (e.g., "the skill that produces a brainstorm requirements doc — currently `ce-brainstorm` — seeds Phase 1 of `process/feature-development-workflow.md`"). For meta-skills with no artifact output (e.g., `ce-compound-refresh`, `ce-debug`), the row says so explicitly so the table does not read as half-filled. Note the upgrade discipline: pin to CE 3.x; re-evaluate at 4.x major version.
+- Footer: **"Real-world deployment example"** subsection (renamed from "Working example") naming `books-ops` with one paragraph qualifying it as a private rmorison deployment, not as a doc reference. No line-range citations.
+- Use repo-relative paths everywhere. Do not point at the books-ops repo for content the integration doc itself should carry.
+
+**Patterns to follow:**
+- `process/issue-tracking.md` voice and structure for the issue-tracking modes section.
+- `process/git-branching-strategy.md` voice for the branch-naming reconciliation section.
+
+**Test scenarios:**
+- Test expectation: none — documentation change. Verification is structural review per the next field.
+
+**Verification:**
+- All five sections present.
+- `docs/solutions/` row in the mapping table; precedence rule + provenance clause stated explicitly.
+- Documentation Paths table is inlined (not linked to books-ops).
+- AI-review discipline section names: (a) what's checked, (b) the four failure modes, (c) explicit "discipline, not enforced gate" framing.
+- Ticket Policy block inlined so adopters can apply without external reference.
+- `books-ops` named only as real-world deployment, never as canonical reference.
+- A reader without rmorison repo access can apply the integration doc end-to-end.
+- No team-scale standards weakened — re-reading every cross-reference shows additive language ("when in solo CE mode...") rather than subtractive ("the standard no longer applies").
+- Skill name changes within CE 3.x wouldn't break the doc (behaviors described alongside names).
+
+---
+
+- U3. **Update `ai/CLAUDE.md` AND `ai/claude-code/rules/` — inline-replace conflicting rules, add CE precedence**
+
+**Goal:** The highest-leverage change. Agents read these files every turn. Inline-replace the conflicting content (workflow paths, branch-naming rule, "wait for confirmation before implementing") so an agent reading top-down does not execute a standards rule that contradicts CE before reaching any override. Side-by-side was rejected because the existing files contain both workflow paths *and* the unqualified branch-naming rule, which directly contradict CE behavior.
+
+**Requirements:** R8, R9, R14
+
+**Dependencies:** U1, U2 (sections point at both).
+
+**Files:**
+- Modify: `ai/CLAUDE.md`
+- Modify: `ai/claude-code/rules/engineering-standards.md` (always-loaded; conflicts on `docs/` tree at lines 27–37 and branch-naming rule at line 44)
+- Modify: `ai/claude-code/rules/sdlc-workflow.md` (always-loaded; "Plan Before Implementing... Wait for explicit confirmation" at lines 13–18 contradicts `lfg`)
+- Modify: `ai/claude-code/README.md` (describes the 4-layer model; needs supersession note pointing at the ADR + integration doc)
+
+**Approach:**
+
+For **`ai/CLAUDE.md`**:
+- **Replace** the existing Documentation Structure block (lines ~54–66) with a two-mode block: "Standards mode (default):" followed by the existing tree, "When using compound-engineering:" followed by the CE path-ownership table inlined from U2. Both modes remain visible — the change is structural reframing, not deletion.
+- **Replace** the unqualified branch-naming line (`ai/CLAUDE.md` line 41: `**Branch naming**: {issue-number}-{slugified-title}`) with a two-mode version: "Standards mode: `{issue-number}-{slugified-title}`. When using compound-engineering: also accepts topic-style `feat/...` / `fix/...` for `lfg` / `ce-work` flows without a parent issue. See `process/compound-engineering-integration.md`."
+- **Replace** the Feature Development Workflow numbered list (lines ~24–29) with a two-mode version: standards-mode list (unchanged) and CE-mode list (Phase 0 = `docs/brainstorms/`, Phase 1 seeded from brainstorm, Phase 3-4 outputs at CE-mode paths). This addresses R9 directly in the highest-leverage file.
+- **Insert** a new "When using compound-engineering" section after the existing Quick Reference block containing: (a) one-line precedence statement with provenance clause summary; (b) pointer to the ADR (U1) and integration doc (U2); (c) one-paragraph framing of AI-review as discipline (not gate); (d) link to the integration doc for the full path-ownership table.
+- Update the Quick Links section at the bottom to include the new ADR and integration doc.
+- Do NOT cite `books-ops/CLAUDE.md` from `ai/CLAUDE.md` — the integration doc is the authoritative reference for CE-mode behavior.
+
+For **`ai/claude-code/rules/engineering-standards.md`** (always-loaded):
+- **Replace** the hardcoded `docs/` tree block (lines 27–37) with a two-mode version mirroring the `ai/CLAUDE.md` treatment: "Standards mode" tree (unchanged), "When using compound-engineering" tree (CE paths). Pointer to integration doc.
+- **Replace** the unqualified Branching line (line 44: `**Branch names**: {issue-number}-{slugified-title}`) with the same two-mode version as `ai/CLAUDE.md`.
+- **Add** a "When using compound-engineering" subsection at the end pointing at the ADR (U1) and integration doc (U2). One paragraph plus links.
+
+For **`ai/claude-code/rules/sdlc-workflow.md`** (always-loaded):
+- **Replace** the "Plan Before Implementing" section (lines 13–18) with a two-mode version: "Standards mode: author a plan and present it before writing any code. Wait for explicit confirmation before proceeding." / "When using compound-engineering: `/ce-plan` produces the plan; `/ce-work` executes it iteratively. The `lfg` autonomous flow runs without per-step confirmation by design — the plan and CE-doc-review steps capture intent up-front instead of via inline approval. Use `lfg` only when you have a complete plan; otherwise default to `/ce-plan` → `/ce-work` with explicit handoff."
+- Other sections (Read Before Changing, Validate After Each Change, Flag Uncertainty, Scope Discipline) are CE-compatible and need no change. Add a one-line top pointer at the file's intro: "When working with compound-engineering, see also `process/compound-engineering-integration.md`."
+
+For **`ai/claude-code/README.md`** (4-layer model description) — this is the **load-bearing architecture doc** for new adopters; expand it to explicitly state CE as the Layer 2/3 specialization:
+- **Update the intro** to state the layering plainly: "This directory defines the AI artifacts layer. Four layers organize AI tooling by context cost. CE specializes Layers 2 and 3 with deep implementations when the plugin is installed; the layers themselves are the abstraction."
+- **Update the Layer 2 (Skills) row**: keep the existing description of `templates/.claude/skills/{spec,plan,review}/` as the vendor-neutral default; **add** a sentence: "When [compound-engineering](https://github.com/EveryInc/compound-engineering-plugin) is installed, CE skills (`/ce-brainstorm`, `/ce-plan`, `/ce-work`, `/ce-doc-review`, `/ce-code-review`, `lfg`, etc.) are the deep specialization of this layer. CE-using projects default to those skills; non-CE projects use the templates' skills. See `process/compound-engineering-integration.md`."
+- **Update the Layer 3 (Agents) row**: keep the existing description of the templates' agents as the vendor-neutral default; **add** a sentence: "When CE is installed, CE persona reviewers (~20 specialized agents covering coherence, feasibility, adversarial, security, performance, etc.) are the deep specialization of this layer."
+- Layers 1 (Rules) and 4 (Hooks) descriptions unchanged structurally; Layer 1 row gets a one-line note that `ai/claude-code/rules/` content is CE-aware (see U3 changes to those rule files).
+- **Add** a "When you adopt CE" subsection at the end with: install pointer, link to the ADR (U1) and integration doc (U2), and a one-paragraph framing reiterating the layering (CE is the deep specialization; the 4-layer architecture itself is unchanged).
+- The file remains the load-bearing description of the AI architecture; it gains depth, does not get superseded.
+
+**Patterns to follow:**
+- Existing `ai/CLAUDE.md` voice — terse, table-heavy, links-out-to-detail.
+
+**Test scenarios:**
+- Test expectation: none — documentation change. Verification is structural review per the next field.
+
+**Verification:**
+- `ai/CLAUDE.md`: Documentation Structure block has explicit baseline / "When using compound-engineering" sub-blocks; branch-naming line carries both rules; Feature Development Workflow numbered list reflects both modes; Phase 0 = `docs/brainstorms/` declared (R9); precedence rule + provenance clause summary present; AI-review described as discipline, not enforced gate; Quick Links updated.
+- `ai/claude-code/rules/engineering-standards.md`: `docs/` tree two-mode; branch-naming line two-mode; CE-mode subsection at end pointing at ADR + integration doc.
+- `ai/claude-code/rules/sdlc-workflow.md`: Plan-Before-Implementing section two-mode (CE-mode covers `lfg` autonomous flow); top pointer to integration doc.
+- `ai/claude-code/README.md`: intro states the layering explicitly (4-layer abstraction + CE as Layer 2/3 specialization); Layer 2 and Layer 3 rows describe both vendor-neutral defaults and CE specializations; "When you adopt CE" subsection present at end. The file is **enriched, not deprecated**.
+- An agent reading any of these files top-down sees the layering before any specific workflow rule; both vendor-neutral and CE-mode rules remain visible and unambiguously labeled.
+- All four files explicitly stress the layering in their intros or top-level structure (per the user-stated requirement that top-level docs make this load-bearing).
+
+---
+
+- U4. **Archive 3 prior `ai/` proposals**
+
+**Goal:** Decisive break from the genuine path-not-taken (build agent-native abstractions ourselves rather than use the 4-layer + CE specialization framing) by relocating three untracked proposal docs to top-level `archive/` with banners pointing at the new ADR. **The 4-layer model that shipped via PRs #16/#19/#21 is NOT archived** — it is the abstraction CE specializes; archiving it would defeat the layering this plan is built on.
+
+**Requirements:** R11
+
+**Dependencies:** U1 (banner references the ADR number).
+
+**Files:**
+- Move: `ai/adoption-roadmap.md` → `archive/adoption-roadmap.md`
+- Move: `ai/agent-native-improvements.md` → `archive/agent-native-improvements.md`
+- Move: `ai/top-3-enhancements.md` → `archive/top-3-enhancements.md`
+- Create: `archive/README.md` (short explainer)
+
+**Kept in place** (NOT archived; they are the vendor-neutral baselines of Layers 2 and 3 of the 4-layer architecture):
+- `templates/.claude/skills/{spec,plan,review}/SKILL.md`
+- `templates/.claude/agents/{code-reviewer,spec-writer}.md`
+- `templates/.claude/hooks/` and `templates/.claude/settings.json` (orthogonal Layer 4 / configuration)
+- `templates/CLAUDE.md` (project template — gets CE-aware additions in U8)
+- `ai/claude-code/README.md` and `ai/claude-code/rules/*.md` (Layer 1 description and content — get CE-aware updates in U3, not archived)
+
+**Approach:**
+
+The three files are currently untracked (per `git status`), so `git mv` would fail with "not under version control." Use: `mkdir -p archive && mv ai/<file>.md archive/<file>.md`, then `git add archive/`. The archival commit is these files' first appearance in history.
+
+Why top-level `archive/` and not `ai/archive/`: agents that recursively load `ai/**/*.md` would still ingest the docs; adopters who pull the `ai/` subtree wholesale into a new project would inherit them. Top-level `archive/` removes both failure modes.
+
+Banner for each archived file (relative path `../docs/engineering/adr/...` — files are 1 level deep under archive/):
+```
+> **Implementation strategy superseded by [ADR-0001: Compound Engineering Integration](../docs/engineering/adr/0001-compound-engineering-integration.md).**
+>
+> This document analyzed agent-native principles and proposed building these abstractions in this repo. We instead adopted the 4-layer AI architecture (PRs #16/#19/#21) plus [compound-engineering](https://github.com/EveryInc/compound-engineering-plugin) as the deep specialization of Layers 2 and 3. Kept here as the evaluative framework that informed the layering decision — the analysis remains the lens for re-evaluating the architecture if circumstances change. See `process/compound-engineering-integration.md` for the current operational doc.
+```
+
+`archive/README.md`: short explainer (one section) describing the three archived docs as the agent-native-analysis path-not-taken, naming the layering chosen instead. Briefly lists the three files with one-line summaries.
+
+**Patterns to follow:**
+- None specific. Banner format mirrors how superseded ADRs are typically marked.
+
+**Test scenarios:**
+- Test expectation: none — file moves and banner additions. Verification is structural per the next field.
+
+**Verification:**
+- All three `ai/*.md` proposals exist at `archive/<name>.md`, with banners and working ADR links.
+- `ls ai/` shows the three files are gone; `ls archive/` shows them present.
+- Recursive globs against `ai/**/*.md` no longer return the archived content.
+- `archive/README.md` exists with the short explainer.
+- **NOT archived (verified still in place)**: `templates/.claude/skills/{spec,plan,review}/`, `templates/.claude/agents/{code-reviewer,spec-writer}.md`, `templates/.claude/hooks/`, `templates/.claude/settings.json`, `templates/CLAUDE.md`, `ai/claude-code/README.md`, `ai/claude-code/rules/*.md`. These are the vendor-neutral baseline and Layer 1 content; they receive CE-aware updates in U3 and U8 but stay in place.
+
+---
+
+- U5. **Update `process/git-branching-strategy.md` — anti-pattern reframe + cross-ref**
+
+**Goal:** Address Claude review gap #5 (R10): the "❌ Branches Without Issues" anti-pattern is a direct contradiction of `lfg` and `ce-work` flows. Reframe to add a CE carve-out, then add the standard "When using compound-engineering" pointer.
+
+**Requirements:** R3, R10
+
+**Dependencies:** U2 (cross-ref points at integration doc).
+
+**Files:**
+- Modify: `process/git-branching-strategy.md`
+
+**Approach:**
+- Edit the "❌ Branches Without Issues" anti-pattern (lines 287–291) to add a one-line carve-out: *"Exception: `lfg` and `ce-work` autonomous flows may produce topic-style branches (`feat/...`, `fix/...`) without a parent issue. File an issue retroactively only if review surfaces something worth tracking. See `process/compound-engineering-integration.md`."*
+- Add a "When using compound-engineering" pointer paragraph near the top of the file (after the Overview section): one-line note with link to integration doc.
+- **Required (R7 cross-ref)**: tweak the Branch Protection block (lines 322–331) to add a one-line note that the "Require at least 1 approval" rule has a CE-mode complement (the AI-review **discipline** defined in `process/compound-engineering-integration.md`). Frame as discipline, not enforced gate; preserve the existing rule. This row delivers the R7 forward-pointer; previously this was marked optional.
+- Do not rewrite the GitHub Flow guidance — it stands.
+
+**Patterns to follow:**
+- Existing voice / formatting in the file.
+
+**Test scenarios:**
+- Test expectation: none — documentation change. Verification per the next field.
+
+**Verification:**
+- Anti-pattern carve-out present and points at the integration doc.
+- Cross-ref pointer present near the top.
+- Branch protection block carries the R7 cross-ref note (required) — preserves the team-scale rule and adds the CE complement, framed as discipline not enforced gate, never weakening.
+
+---
+
+- U6. **Cross-references in remaining four standards docs**
+
+**Goal:** Add the minimal "When using compound-engineering" pointers required by issue #22's acceptance criterion, plus the targeted update for review gap #4 (Phase 0 = brainstorm in feature workflow). R7 is delivered by U2 + U5 promotion; no longer attributed to U6.
+
+**Requirements:** R3, R5, R9
+
+**Dependencies:** U2.
+
+**Files:**
+- Modify: `process/feature-development-workflow.md`
+- Modify: `process/issue-tracking.md`
+- Modify: `process/project-planning-standards.md`
+- Modify: `process/documentation-standards.md`
+
+**Approach:**
+- **`process/feature-development-workflow.md`** — add a "When using compound-engineering" note in or just before Phase 1 (lines 40–46) declaring that `docs/brainstorms/<topic>-requirements.md` (the `ce-brainstorm` output) IS the Phase 0 / discovery artifact and that Phase 1 (Product Concept) is seeded from it (R9). Pointer to integration doc.
+- **`process/issue-tracking.md`** — add a "When using compound-engineering" cross-ref near the Three-Tier Hierarchy section (around line 19) pointing at the integration doc's solo-mode subsection. Cite the existing carve-outs at lines 359–373 as the foundation. No structural change.
+- **`process/project-planning-standards.md`** — add a "When using compound-engineering" cross-ref near the Team Estimation section (lines 79–86) noting that for solo CE work, point estimates in CE plan files serve as self-calibration; planning poker is N/A. Pointer to integration doc.
+- **`process/documentation-standards.md`** — add a "When using compound-engineering" cross-ref in or near the Directory Structure section (lines 9–47) noting that CE-skill outputs live at `docs/brainstorms/`, `docs/ideation/`, `docs/plans/`, `docs/solutions/` per the integration doc's path mapping. No structural change.
+- Each cross-ref is 1–3 lines, additive, points at `process/compound-engineering-integration.md`. No team-scale standards weakened.
+
+**Patterns to follow:**
+- Existing voice in each file. Match the existing cross-ref style (e.g., the way `process/feature-development-workflow.md` already cross-refs `process/project-planning-standards.md`).
+
+**Test scenarios:**
+- Test expectation: none — documentation changes. Verification per the next field.
+
+**Verification:**
+- All four files have a CE cross-ref.
+- Phase 0 = brainstorm note exists in feature-development-workflow.md (R9).
+- Solo-mode pointer in issue-tracking.md cites existing carve-outs (R5: not weakening).
+- Planning poker N/A note in project-planning-standards.md cites the existing line 86 carve-out (R5: not weakening).
+- Documentation paths note in documentation-standards.md.
+
+---
+
+- U7. **Add CE-as-specialization subsection to README + Process Standards entry**
+
+**Goal:** Make the integration discoverable from the README without disturbing the existing 4-layer description (which remains accurate). The 4-layer is the abstraction; CE is the specialization. The README's existing AI Integration section already describes the abstraction correctly; we add the specialization subsection alongside it. **This is critical for new-adopter onboarding** — the README is the front door; the layering must be visible there.
+
+**Requirements:** R3, R5, R16
+
+**Dependencies:** U1, U2.
+
+**Files:**
+- Modify: `README.md`
+
+**Approach:**
+- In the existing "AI / Claude Code Integration" section (lines 96–117): **add** a brief "When the compound-engineering plugin is installed" subsection right after the existing 4-layer list. The subsection states (in 1–2 paragraphs):
+  - "CE specializes Layers 2 (Skills) and 3 (Agents) of the architecture above. When CE is installed, its skills (`/ce-brainstorm`, `/ce-plan`, `/ce-work`, `/ce-code-review`, `/ce-doc-review`, `lfg`, etc.) and persona reviewers replace the templates' vendor-neutral defaults for those layers. Layers 1 (Rules) and 4 (Hooks) are unchanged."
+  - "See [ADR-0001](docs/engineering/adr/0001-compound-engineering-integration.md) for the architectural decision and [`process/compound-engineering-integration.md`](process/compound-engineering-integration.md) for adoption details."
+- In the existing 4-layer table: **add** to the Layer 2 row a parenthetical "(or CE skills when CE is installed)"; same for Layer 3 with "(or CE persona reviewers)". Layers 1 and 4 unchanged.
+- **Add** a Process Standards entry for `process/compound-engineering-integration.md` between the existing Issue Tracking section and the AI / Claude Code Integration section. One paragraph, ≤4 lines.
+- **Add** one line under "Applying These Standards" noting that projects using the compound-engineering plugin should consult the integration doc for path mapping and review discipline.
+- Do not restructure other sections; do not rewrite the 4-layer description.
+
+**Patterns to follow:**
+- Existing README voice. The 4-layer description's "Key principle" framing stays — it applies to CE too.
+
+**Test scenarios:**
+- Test expectation: none — documentation change. Verification per the next field.
+
+**Verification:**
+- README's "AI / Claude Code Integration" section retains the existing 4-layer description verbatim.
+- Layer 2 and Layer 3 rows of the layer table carry parenthetical CE-specialization notes.
+- A new "When the compound-engineering plugin is installed" subsection follows the layer description.
+- README has a Process Standards entry for the integration doc.
+- "Applying These Standards" section includes a CE pointer.
+- A reader landing on the README first sees the 4-layer abstraction, then the CE specialization — the architecture is visible before any specific workflow.
+- The README explicitly stresses the layering (per the user-stated requirement: "make sure top-level docs stress this").
+
+---
+
+- U8. **Add CE-aware section to `templates/CLAUDE.md`**
+
+**Goal:** Templates ship as a starter kit. Adopters who copy `templates/CLAUDE.md` into a CE-using project should see CE-mode guidance reflecting the layering — without disrupting the template for non-CE adopters.
+
+**Requirements:** R15
+
+**Dependencies:** U2 (the new section references the integration doc).
+
+**Files:**
+- Modify: `templates/CLAUDE.md`
+
+**Approach:**
+- Edit the "Plan Before Implement" section (lines 14–17) to add a one-line CE-aware note: "When the compound-engineering plugin is installed, `/ce-plan` produces the plan and `/ce-work` executes it; `lfg` runs autonomously without per-step confirmation. See `process/compound-engineering-integration.md` for the full pattern."
+- Edit "Standards References" (lines 19–22) to add a line: "- Compound-engineering integration (when CE is installed): process/compound-engineering-integration.md"
+- Add a brief "AI Architecture" section after "Standards References" with one paragraph explaining the layering: "This template assumes the 4-layer AI architecture defined in `ai/claude-code/README.md`. Layers 1 (Rules) and 4 (Hooks) are filled by the standards repo's `ai/claude-code/rules/` and `templates/.claude/hooks/`. Layers 2 (Skills) and 3 (Agents) are filled by `templates/.claude/skills/` and `templates/.claude/agents/` by default; when [compound-engineering](https://github.com/EveryInc/compound-engineering-plugin) is installed, CE skills and persona reviewers specialize those layers."
+- Do not restructure other sections (Module Boundaries, Validation, Project Identity).
+- `templates/.claude/settings.json` is not modified — its `permissions.allow` list is reasonable and CE-compatible as-is.
+
+**Patterns to follow:**
+- Existing `templates/CLAUDE.md` voice — minimal, placeholder-driven.
+
+**Test scenarios:**
+- Test expectation: none — documentation change. Verification per the next field.
+
+**Verification:**
+- `templates/CLAUDE.md`: Plan-Before-Implement carries CE-aware note; Standards References lists the integration doc; new "AI Architecture" section explains the layering.
+- An adopter who copies the template to either a CE-using or non-CE project gets correct guidance — the layering tells them what to expect either way.
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** AI agents reading `ai/CLAUDE.md` (U3) get the precedence rule first, then follow pointers to the ADR (U1) and integration doc (U2). The integration doc is the load-bearing operational reference; the cross-refs in the five process docs (U5, U6) are signposts back to it. The README update (U7) is the human-discovery entry point.
+- **Error propagation:** If the integration doc drifts out of sync with CE behavior (e.g., a skill name change), the failure mode is "agent reads the doc, can't find the named skill, falls back to behavior description." The doc's structure (behavior described alongside name in the cross-reference table) bounds the blast radius.
+- **State lifecycle risks:** None — this is a documentation change with no runtime state.
+- **API surface parity:** N/A — no APIs.
+- **Integration coverage:** The acceptance criterion that "no team-scale standards are weakened" requires re-reading every cross-ref in U5/U6 to verify additive (not subtractive) language. Catch this in Verification on each unit, then again in the final review (Phase 5.1).
+- **Unchanged invariants:** ADR location (`docs/engineering/adr/`), Fibonacci estimation scale, conventional commits, `main` always deployable, PR-based merges, GitHub Flow, semver, code quality principles, documentation formats. The integration doc and ADR confirm these explicitly.
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| The integration doc tries to be both prescriptive (override standards) and descriptive (document books-ops) and reads confusingly. | Clear section structure: prescriptive material in the five named sections; books-ops mentioned only in a "Real-world deployment example" footer with no line-range citations. Load-bearing tables and paragraphs are inlined, not pointed at. Re-read for tone in Phase 5.1. |
+| `ai/CLAUDE.md` rewrite breaks non-CE adopters who copy this template. | Inline replacement uses explicit "Standards mode (default):" / "When using compound-engineering:" sub-blocks; both modes remain visible. A non-CE adopter's reading is unchanged in semantics — only the structure is reframed. |
+| CE skill names change in a future plugin version, breaking the cross-reference table in U2. | Describe behavior alongside skill names ("the skill that produces a brainstorm requirements doc — currently `ce-brainstorm`"). Localizes the rot. Upgrade discipline pinned at CE 3.x with re-evaluation at 4.x major version (R12). |
+| AI-review discipline (R7) is misread as an enforced gate, leading to false confidence. | The integration doc explicitly frames the discipline as "process discipline, not enforced by repo configuration." Failure modes named explicitly (cross-PR scope drift, self-grading loops, product-positioning regressions, same-intent author/reviewer). Adopters know what they're trading. |
+| Single-PR scope (~400–500 lines / ~10–12 files) is close to `process/git-branching-strategy.md`'s 200-400-line target after specialization-framing pass. | The standard has no formal PR-size deviation clause. The artifacts cross-reference each other (ADR ↔ integration doc ↔ `ai/CLAUDE.md` ↔ `ai/claude-code/rules/` ↔ README), so single-PR scope is the right call at this size. Split is still possible if review surfaces seams. |
+| Layer-architecture framing is novel to this repo and may not land if not stressed in top-level docs. | U1 (ADR), U3 (`ai/claude-code/README.md`, `ai/CLAUDE.md`), U7 (README), U8 (`templates/CLAUDE.md`) all explicitly state the layering. The framing is repeated across the doc surface so a reader who lands anywhere sees it. |
+| Vendor coupling to CE/EveryInc creates a maintenance liability against a roadmap the repo doesn't control. | ADR carries a "Why this plugin specifically" subsection (R12) defending the choice and stating the upgrade discipline. The standards repo's audience is small enough to make pinning lower-cost than maintaining vendor-neutral abstractions. Re-evaluation point: CE 4.x major version. |
+| Precedence rule edge cases (co-authored docs, human-edited CE artifacts) leave provenance ambiguous in practice. | Provenance clause (R13) defines first-skill-touched-the-file as the default with explicit `provenance:` frontmatter override as the escape hatch. Stated in both the ADR and the integration doc. |
+| books-ops working example is private; non-rmorison readers cannot verify referenced content. | Resolved by inlining all load-bearing content (Documentation Paths table, Review Discipline, Ticket Policy) directly into the integration doc. books-ops named only as "real-world deployment example" with no line-range citations. The integration doc is now self-contained for any public reader. |
+| Three `ai/*.md` archived files are currently untracked; the archival commit looks unusual in history. | U4 approach explicitly addresses this: archival commit is the files' first appearance in history; no `git mv` for that batch (would fail on untracked files); banner makes the supersession explicit. The skill/agent batch IS tracked and uses `git mv` to preserve history. |
+| Re-deriving "what fills Layer 2 / 3" per project remains a per-adopter decision. | The ADR + integration doc document the layering once; adopters copy `templates/CLAUDE.md` (with the AI Architecture section from U8) which carries the framing forward into their project. Books-ops becomes the working reference for "CE installed → CE specializes Layers 2/3." |
+
+---
+
+## Documentation / Operational Notes
+
+- After merge: notify books-ops to refresh its CLAUDE.md to point at the now-published integration doc instead of the in-flight #22 reference. Books-ops' `CLAUDE.md` already says "see engineering-standards#22 for the in-flight upstream proposal" in two places; those become "see `process/compound-engineering-integration.md`." books-ops can also drop its locally-absorbed Documentation Paths table since the integration doc now carries it canonically.
+- No CI changes, no migrations, no runtime impact. Pure documentation and three file relocations.
+- Issue #12 (Add Phase 0 to feature workflow): R9 partially addresses it for CE-mode adopters by declaring `docs/brainstorms/` as the Phase 0 artifact. Before closing #12, verify whether its acceptance language requires Phase 0 for non-CE adopters too — if so, leave it open and capture the gap as a follow-up.
+- Issues #16, #19, #21 (the 4-layer architecture): not closed by this PR. The ADR builds on their architecture (4-layer model is the abstraction; CE specializes Layers 2/3) — those issues remain valid completed work. No supersession comment needed; the relationship is described in the ADR and the integration doc.
+- PR description: name the 4-layer-as-abstraction + CE-as-specialization framing prominently. The framing is the central architectural contribution of this PR; surfacing it in the description helps reviewers understand the structural choice before they evaluate individual file diffs.
+
+---
+
+## Sources & References
+
+- **Origin issue:** [rmorison/engineering-standards#22](https://github.com/rmorison/engineering-standards/issues/22)
+- **Real-world deployment example:** `books-ops` (private rmorison repo) — informed the integration doc's wording during real use of the brainstorm → plan → ce-doc-review → lfg pipeline. Not a doc reference; the integration doc inlines its own load-bearing content so public readers do not need books-ops access.
+- **Related issue:** [rmorison/engineering-standards#12](https://github.com/rmorison/engineering-standards/issues/12) (Phase 0 — partially addressed by R9 for CE-mode adopters; verify acceptance language before closing)
+- **Built on:** [rmorison/engineering-standards#16](https://github.com/rmorison/engineering-standards/issues/16) (4-layer AI architecture), [#19](https://github.com/rmorison/engineering-standards/issues/19) (README documentation of #16), [#21](https://github.com/rmorison/engineering-standards/issues/21) (PascalCase hook fix). The 4-layer model is the abstraction this plan extends with CE as the deep specialization of Layers 2 and 3.
+- **CE plugin:** https://github.com/EveryInc/compound-engineering-plugin (v3.1.0; upgrade discipline pinned at 3.x with re-evaluation at 4.x)
+- **Agent-native foundation:** https://every.to/guides/agent-native (the framework that informed the now-archived prior proposals; retained as the evaluative lens for re-evaluating CE adoption)
+- **Archived prior `ai/` proposals:** `archive/adoption-roadmap.md`, `archive/agent-native-improvements.md`, `archive/top-3-enhancements.md` (after U4 — top-level `archive/`)
+- **Affected files:** `process/feature-development-workflow.md`, `process/issue-tracking.md`, `process/project-planning-standards.md`, `process/documentation-standards.md`, `process/git-branching-strategy.md`, `ai/CLAUDE.md`, `ai/claude-code/rules/engineering-standards.md`, `ai/claude-code/rules/sdlc-workflow.md`, `ai/claude-code/README.md`, `templates/CLAUDE.md`, `README.md`
+- **Doc-review provenance:** plan revised 2026-05-03 after two rounds of multi-persona review (coherence, feasibility, product-lens, scope-guardian, adversarial). Round 1 fixes: books-ops privacy resolved by inlining, AI-review reframed as discipline not gate, vendor coupling defended in ADR, precedence-rule provenance clause added, archives moved to top-level `archive/`. Round 2 surfaced the layer-architecture framing: the 4-layer model (PRs #16/#19/#21) and CE are at different levels of abstraction — 4-layer is the taxonomy of context-cost slots; CE is the deep specialization of Layers 2 and 3. Plan revised around this framing: dropped R15 (lightweight skill/agent archival) entirely, simplified R16 (additive README, not rewrite), reframed Key Technical Decisions, U1, U3, U4, U7, U8 around layering. Remaining round-2 findings (issue supersession comments, templates/README.md staleness, provenance frontmatter brittleness, archive directory naming) captured in Open Questions / From 2026-05-03 doc-review (deferred) where applicable; many became moot once R15 was dropped.

--- a/docs/plans/2026-05-03-002-refactor-ai-architecture-6-layer-model-plan.md
+++ b/docs/plans/2026-05-03-002-refactor-ai-architecture-6-layer-model-plan.md
@@ -1,0 +1,641 @@
+---
+title: "refactor: Adopt 6-layer AI architecture with compound-engineering as canonical realization"
+type: refactor
+status: active
+date: 2026-05-03
+origin: https://github.com/rmorison/engineering-standards/issues/22
+prior_plan: docs/plans/2026-05-03-001-feat-compound-engineering-integration-plan.md
+---
+
+# refactor: Adopt 6-layer AI architecture with compound-engineering as canonical realization
+
+## Overview
+
+This plan implements the architectural redesign described in rescoped issue #22. The repo currently ships a **4-layer AI architecture** (Rules / Skills / Agents / Hooks) introduced via PRs #16/#19/#21 (~5 weeks ago). Under that model, `ai/claude-code/rules/*.md` are Layer 1, `templates/.claude/skills/{spec,plan,review}/` are Layer 2, `templates/.claude/agents/{code-reviewer,spec-writer}.md` are Layer 3, and `templates/.claude/hooks/` are Layer 4. The 4-layer was a useful first sketch but a tactical CE-integration attempt (the abandoned prior plan, three rounds of multi-persona doc-review) revealed that CE doesn't fit it cleanly — CE has structural patterns the 4-layer doesn't name (References, Compound/Learnings) and the existing layers' definitions force category errors (CE personas aren't standalone Layer-3 agents).
+
+This plan evolves the architecture to a **6-layer model**:
+
+1. **Rules** — always-loaded session context (compact pointers, behavioral guardrails)
+2. **Workflow Skills** — composable on-demand workflows that orchestrate multi-step processes
+3. **Persona Agents** — specialized review/analysis perspectives, dispatched by skills (or directly invocable for simple cases)
+4. **References** — skill-loaded progressive context that grows as workflow depth grows
+5. **Compound / Learnings** — institutional knowledge accumulation that feeds forward into future work
+6. **Hooks** — deterministic non-AI enforcement at zero context cost
+
+The architecture is the **abstraction**; **compound-engineering** (CE) is named as one **canonical realization**. Layer definitions are vendor-neutral so other LLM-engineering toolkits — present or future — can fit the same slots. The vendor-neutral templates' skills/agents stay in place as Layer 2/3 baseline implementations for projects that don't run CE; CE provides deeper Layer 2/3 implementations for projects that install the plugin. Layer 5 (Compound) is new and currently realized only by CE; Layers 1, 4, and 6 are owned by the standards repo and are not vendor-coupled.
+
+The architectural artifacts (ADR, `ai/claude-code/README.md`) are written with **publication-quality framing**: standalone, vendor-neutral architectural description suitable for the repo's role as an encompassing standard for future work and as foundation for a potential follow-on technical article (*"Abstracting the Every Compound Engineering Model for LLM Based Engineering"*).
+
+---
+
+## Problem Frame
+
+The repo's identity is "lightweight standards anyone can adopt" with branches for different project types. AI-tooling guidance is part of the standards surface. The current 4-layer model has three concrete inadequacies once compared to a developed system like CE:
+
+1. **Layer 3 collapses two distinct shapes**: the 4-layer's Layer 3 def assumes "specialized subagents directly invoked." CE's persona reviewers are skill-internal prompt templates dispatched by orchestrators (`ce-doc-review`, `ce-code-review`); they don't run standalone. The abandoned plan's attempt to call CE skills "Layer 3" was a category error the layer model invited.
+2. **Layer 2 conflates lazy-and-minimal with lazy-and-deep**: the templates' skills are 30–60 lines and load standards via URL. CE skills are 800–1500 lines plus reference subtrees. Both are lazy-loaded, but the load profiles differ by orders of magnitude. Calling them the same Layer 2 paper-thinly hides a real depth tradeoff.
+3. **References and Compound/Learnings are unnamed structural patterns**: CE skills ship `references/*.md` subtrees that progressively load context during execution. CE captures learnings via `ce-compound` + `docs/solutions/`. The 4-layer model has no slot for either — the patterns are real but inarticulable in the existing taxonomy.
+
+The fix is not to "supersede" the 4-layer (the abandoned plan's first framing) or "specialize within it" (the abandoned plan's second framing). The fix is to evolve the architecture itself to absorb the patterns CE has surfaced — keeping it general enough that the abstraction stays vendor-neutral while CE serves as the canonical realization adopters point to.
+
+The work is also positioned for **publication**: the user is considering a follow-on technical article abstracting CE's model. That requires the architecture artifacts to be readable by external readers without rmorison context.
+
+---
+
+## Requirements Trace
+
+The requirements derive from the rescoped issue's acceptance criteria plus operational findings carried forward from the abandoned prior plan.
+
+- **R1.** ADR establishes the 6-layer architecture, articulates each layer's definition, names CE as canonical realization, and frames the architecture-as-abstraction / CE-as-realization relationship.
+- **R2.** `ai/claude-code/README.md` rewrites as the canonical 6-layer description with publication-quality framing — readable as standalone architectural description.
+- **R3.** `ai/CLAUDE.md` reflects the 6-layer architecture (CE-aware path mappings, branch-naming carve-out, Phase 0 = brainstorm declaration where CE is in use).
+- **R4.** `ai/claude-code/rules/engineering-standards.md` and `ai/claude-code/rules/sdlc-workflow.md` content is CE-aware while staying compact-pointer in shape (Layer 1's <150-line discipline preserved). Two-mode policy lives in U5 (integration doc) and U3 (`ai/CLAUDE.md`), not in Layer 1.
+- **R5.** Integration process doc `process/compound-engineering-integration.md` describes CE's realization of each of the 6 layers and the operational details: artifact path mapping, issue-tracking modes, branch-naming reconciliation, AI-review **discipline** (not enforced gate), CE skill ↔ standards doc cross-reference. Self-contained — load-bearing content inlined; no public reader needs rmorison or books-ops access.
+- **R6.** README's "AI / Claude Code Integration" section rewrites to reflect the 6-layer model. Adds CE as canonical realization. Keeps the "Context is expensive" principle (it transfers cleanly to the new model).
+- **R7.** `templates/CLAUDE.md` updated with a brief "AI Architecture" section reflecting the 6-layer model and a CE-aware note in "Plan Before Implement."
+- **R8.** Cross-references added to: `process/feature-development-workflow.md`, `process/issue-tracking.md`, `process/project-planning-standards.md`, `process/documentation-standards.md`, `process/git-branching-strategy.md`. The branching standard also gets a CE carve-out for `lfg`/`ce-work` topic-style branches and a Layer-3-discipline note in branch protection.
+- **R9.** Three prior `ai/*.md` proposals (`adoption-roadmap.md`, `agent-native-improvements.md`, `top-3-enhancements.md`) relocated to top-level `archive/` with banners pointing at the new ADR. These are the genuine path-not-taken: they proposed building agent-native abstractions ourselves rather than adopting a developed toolkit.
+- **R10.** No team-scale standards weakened — every cross-reference is additive ("when CE is in use..."), never subtractive.
+- **R11.** All AI-architecture artifacts written with publication-quality framing — vendor-neutral layer definitions, CE as one realization, no rmorison-specific assumptions in top-level docs.
+- **R12.** Layer definitions are general enough that other LLM-engineering toolkits (or hand-rolled implementations) could fit the same slots. The architecture description should answer "what would Layer 2 look like in Cursor / Aider / a hand-rolled system" without contradiction.
+- **R13.** Operational findings from the abandoned prior plan carried forward where still valid:
+   - Books-ops privacy resolved by inlining all load-bearing content; books-ops named only as "real-world deployment example"
+   - AI-review framed as **discipline**, not an enforced merge gate; failure modes named explicitly (cross-PR scope drift, self-grading loops, product-positioning regressions, same-intent author/reviewer)
+   - Provenance clause for artifact paths: first-skill-touched-the-file wins; explicit `provenance:` frontmatter override
+   - `docs/brainstorms/` declared as Phase 0 / discovery artifact for the feature workflow when CE is in use (partially addresses #12)
+   - Branch-naming carve-out for `lfg` / `ce-work` autonomous flows (topic-style accepted when no parent issue)
+   - Solo carve-outs from existing standards (cite — not invent — the existing `process/issue-tracking.md` and `process/project-planning-standards.md` solo escape hatches)
+
+---
+
+## Scope Boundaries
+
+- **The technical article itself** is a separate publishing track. This plan produces the architectural artifacts the article would draw on; the article is not in scope.
+- **Forking compound-engineering** or maintaining its skill content here.
+- **Tracking CE's version updates inside the standards** — the integration doc describes CE-skill behavior alongside names, so name churn within 3.x is a one-row table edit. Re-evaluate at CE 4.x.
+- **Rewrites of `code/python-standards.md`, `code/database-standards.md`, `code/web-application-standards.md`** to add CE-skill cross-references. Surface in a follow-up only if real use shows a gap.
+- **CE-mode enforcement hooks** (e.g., a hook that warns if `/plan` is invoked in a CE project). The 4-layer's example hooks remain in place as Layer 6 baseline; project-specific enforcement can be a follow-up.
+- **Project-specific wrapper skills** (e.g., `templates/.claude/skills/ce-plan-wrapper/` that pre-fills repo conventions). Adds vendor coupling at the template level; defer until concrete need.
+- **Layer 5 (Compound) tooling stubs** in templates. The integration doc and ADR describe Layer 5; if a concrete `templates/.claude/learnings/` or similar artifact is needed, that is a follow-up driven by first compound output.
+- **Migration guide for hypothetical external adopters** of the prior 4-layer model. Repo has no external-adopter signals; if real adopters surface concerns post-merge, address in a follow-up.
+
+### Deferred to Follow-Up Work
+
+- Branch rename from `22-integrate-compound-engineering-practices-with-the-standards-repo` to a name reflecting the new title (e.g., `22-refactor-ai-architecture-6-layer-model`). Optional cosmetic; current slug is functional and a rename can happen at any point with `git branch -m`. Decision deferred to the implementer.
+- Retroactive comments on issues #16 / #19 / #21 indicating the architecture has evolved (not superseded — the 4-layer principle is preserved). Cheap to add post-merge if the issue tracker becomes a discovery surface.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `ai/claude-code/README.md` (88 lines) — current 4-layer description. The Layer table and "Key principle: context is expensive" framing transfer cleanly to the 6-layer; structural rewrite needed for the additional layers and refined definitions.
+- `ai/claude-code/rules/engineering-standards.md` (59 lines) — Layer 1 content; hardcoded `docs/` tree (lines 27–37) and unqualified branch-naming (line 44) need CE-aware updates while staying compact-pointer in shape.
+- `ai/claude-code/rules/sdlc-workflow.md` (39 lines) — "Plan Before Implementing" (lines 13–18) contradicts CE's `lfg` autonomous flow; needs a one-line addendum pointing at the integration doc, not a multi-mode rewrite.
+- `ai/CLAUDE.md` (lines ~22–66) — Quick Reference Documentation Structure, Feature Development Workflow numbered list, branch-naming rule. Needs two-mode framing inline (vendor-neutral baseline + CE-mode addendum) for each block.
+- `templates/CLAUDE.md` (62 lines) — project template. "Plan Before Implement" + "Standards References" sections accept CE-aware additions; new "AI Architecture" section reflects 6-layer model.
+- `README.md` (lines 96–117) — current "AI / Claude Code Integration" section describes 4-layer. Rewrite to describe 6-layer with CE as canonical realization.
+- `process/feature-development-workflow.md` Phase 1 (lines 40–70) — seam where Phase 0 (CE brainstorm) attaches.
+- `process/issue-tracking.md` lines 359–373 — existing solo carve-outs ("<3 issues: just use labels", "<1 month: might not need epic structure"). Cite, don't invent.
+- `process/project-planning-standards.md` line 86 — existing solo carve-out for individual estimation.
+- `process/git-branching-strategy.md` lines 287–291 — "❌ Branches Without Issues" anti-pattern needs a `lfg`/`ce-work` carve-out. Lines 322–331 — branch protection block where AI-review discipline cross-ref attaches.
+- `process/documentation-standards.md` line 125 — "each `docs/` subdirectory should have a `README.md`."
+- `templates/.claude/skills/{spec,plan,review}/SKILL.md` — vendor-neutral Layer 2 baseline. **Stays in place** (not archived).
+- `templates/.claude/agents/{code-reviewer,spec-writer}.md` — vendor-neutral Layer 3 baseline. **Stays in place** (not archived).
+- `templates/.claude/hooks/`, `templates/.claude/settings.json` — Layer 6 baseline + config. Stay in place; no changes needed.
+
+### CE structure (verified against `~/.claude/plugins/cache/compound-engineering-plugin/3.1.0/`)
+
+- **Skills**: ~30 skills in `skills/ce-*/` and `skills/lfg/` — slash-commands implementing workflow orchestrators. Each skill has a `SKILL.md` plus typically a `references/` subtree.
+- **Agents**: ~50 agents in `agents/ce-*-reviewer.agent.md` etc. — persona prompt templates dispatched by skills (rarely invoked standalone).
+- **References**: `skills/<name>/references/*.md` — progressive context loaded during skill execution.
+- **Compound**: `ce-compound`, `ce-compound-refresh`, plus `docs/solutions/` artifact pattern.
+- **Layer 1 / Layer 4**: CE doesn't ship these — the standards repo's `ai/claude-code/rules/` and `templates/.claude/hooks/` retain ownership.
+
+### Institutional Learnings
+
+- The abandoned prior plan (`docs/plans/2026-05-03-001-feat-compound-engineering-integration-plan.md`, status: abandoned) documents three rounds of doc-review iteration. Operational findings preserved as input; architectural framing was wrong. Treat the abandoned plan's R-IDs and U-IDs as void; this plan starts fresh.
+- Three rounds of multi-persona review converged on the same insight: any framing that forced CE to fit the 4-layer broke down. The 6-layer evolution is the framing the iteration arrived at.
+- `docs/solutions/` doesn't exist yet in this repo — Layer 5 (Compound) is described in the architecture but doesn't yet have realized output. First compound output will populate it.
+
+### External References
+
+- Compound-engineering plugin: https://github.com/EveryInc/compound-engineering-plugin (v3.1.0)
+- Every.to agent-native foundation: https://every.to/guides/agent-native (informed both the 4-layer design and CE itself)
+- Books-ops working example: private rmorison repo at `/home/rod/Projects/github.com/rmorison/books-ops` — informed the integration doc's wording during real use of the brainstorm → plan → ce-doc-review → lfg pipeline. Not a doc reference for content; the integration doc inlines its own load-bearing material.
+
+---
+
+## Key Technical Decisions
+
+- **Architecture-as-abstraction, CE-as-canonical-realization** (R1, R11, R12). The 6-layer model is described in vendor-neutral terms. CE is named as one realization adopters can install. The vendor-neutral baseline (templates' skills/agents, standards' rules/hooks) is sufficient for projects that don't run CE. Rationale: preserves the repo's "encompassing standard" identity while honestly naming CE's role; supports the publication-quality framing without coupling the architecture description to one vendor.
+
+- **Layer 1 stays compact-pointer** (R4). The Layer 1 rule files get one-line CE-aware additions ("when CE is in use, see `process/compound-engineering-integration.md` for path/branch/workflow conventions") rather than two-mode policy inline. Multi-mode policy lives in `ai/CLAUDE.md` (R3) and the integration doc (R5). Rationale: Layer 1's <150-line discipline is the principle that makes always-loaded context affordable; inlining two-mode policy violates the principle even if numerically under 150 lines.
+
+- **Vendor-neutral Layer 2/3 baselines stay in place** (R10, R12). `templates/.claude/skills/{spec,plan,review}/` and `templates/.claude/agents/{code-reviewer,spec-writer}.md` are not archived. They are the Layer 2 / Layer 3 implementations for projects that don't install CE. CE provides deeper Layer 2/3 implementations when present. Rationale: archiving them would couple the architecture to CE; the layering's vendor-neutrality depends on having a baseline that exists without CE.
+
+- **Layer 5 (Compound/Learnings) is new and currently CE-only**. The architecture describes Compound as a layer with one canonical realization (CE's `ce-compound` + `docs/solutions/`). Non-CE adopters have no realized Layer 5; the layer's description names what would fill it (learning docs, retrospective notes, postmortem repository) so adopters can populate it with hand-rolled implementations if they choose. Rationale: capturing Compound as a layer is the architectural insight CE surfaced; not naming it just because non-CE realizations are thin would lose the insight.
+
+- **AI-review as discipline, not enforced gate** (R5, R13). The integration doc names this explicitly: there is no CI check, branch-protection automation, or PR template that enforces "no unresolved P0/P1 findings." The discipline names what's checked (`ce-code-review`, `ce-doc-review`, self-review against acceptance criteria) and the failure modes the discipline does not catch (cross-PR scope drift, self-grading loops, product-positioning regressions, same-intent author/reviewer). Under the 6-layer model, CE persona reviewers are Layer 3 (skill-internal personas dispatched by `ce-doc-review` and `ce-code-review` skills); the *discipline* is a pattern of using Layer 2 skills to consume Layer 3 personas.
+
+- **Provenance clause for artifact paths** (R5, R13). When a CE skill produces an artifact, CE paths and conventions win; standards paths and conventions own human-authored artifacts and ADRs. Edge cases: (a) **first-skill-touched-the-file wins** by default; (b) **explicit reclassification** is allowed via a one-line `provenance:` frontmatter note when the default rule produces the wrong answer. The default is unverifiable from filesystem state alone, so the frontmatter override is the load-bearing escape hatch.
+
+- **Self-contained integration doc** (R5, R13). All load-bearing content (Documentation Paths table, Review Discipline, Ticket Policy block) is inlined directly into `process/compound-engineering-integration.md`. Books-ops is named once in a "Real-world deployment example" footer, qualified as private. No public reader needs rmorison or books-ops access to apply the integration doc end-to-end.
+
+- **Single-PR scope** (~500–700 lines / ~12–14 files). Rationale: artifacts cross-reference each other (ADR ↔ `ai/claude-code/README.md` ↔ integration doc ↔ `ai/CLAUDE.md` ↔ rules/templates/README); splitting forces stub artifacts. Closer to standards' 200-400 target than the abandoned plan's ~900–1100. Split is available if review surfaces seams (U1+U2 first; everything else follows).
+
+- **Publication-quality framing** (R11). Architectural artifacts (ADR in U1, `ai/claude-code/README.md` in U2) are written so a reader without rmorison context can understand the architecture standalone. Layer definitions don't reference rmorison projects. CE is named as a realization, not as the only realization. The framing supports a follow-on technical article without pre-committing to it.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- 6-layer model adopted (heavy morph). The 4-layer was a useful first sketch; the 6-layer is the evolution.
+- CE is canonical realization; vendor-neutral baselines stay in place. Coexistence is real; vendor-neutrality is preserved by the layering itself.
+- Publication-quality framing is required. Top-level architectural docs must be readable standalone.
+- Operational findings from the abandoned prior plan carry forward (R13 enumerates).
+- Layer 1 stays compact-pointer; CE-mode policy lives elsewhere.
+- AI-review is discipline, not enforced gate.
+
+### Deferred to Implementation
+
+- **Branch rename**: optional cosmetic. Current branch slug works; the implementer can rename mid-PR with `git branch -m` and `git push -u origin <new-name>` if desired. The plan does not require it.
+- **Exact wording of layer definitions** in `ai/claude-code/README.md`. Publication-quality requires careful drafting; the plan specifies the structural shape but not the exact prose. Implementer drafts; ce-doc-review or self-review verifies.
+- **Layer 5 stub in templates**: should `templates/.claude/learnings/` exist as a stub directory pointing at CE's `ce-compound` workflow, or wait until first compound output? Default: skip the stub (no compound output yet to organize); revisit when first `ce-compound` invocation produces a real `docs/solutions/` entry.
+- **Issue #12 closure**: R13 carries forward Phase 0 = brainstorm declaration for CE-mode adopters. Verify #12's actual acceptance language before closing — if it requires Phase 0 for non-CE adopters too, leave it open and capture as follow-up.
+- **Retroactive comments on PRs #16/#19/#21**: optional. The architecture has evolved, not superseded; the principle ("context is expensive") is preserved. A one-line comment on each pointing at this PR is cheap if discoverability becomes a concern post-merge.
+- **Archive directory naming for the README within `archive/`**: whether `archive/README.md` is needed or whether per-file banners are sufficient. Default: include `archive/README.md` since two narratives (the path-not-taken proposals, plus future archive entries) benefit from a directory-level explainer.
+
+---
+
+## High-Level Technical Design
+
+The architecture has six layers ordered by context-cost and invocation pattern. This sketch communicates the shape the artifacts will describe; it is directional guidance for review, not implementation specification.
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│  6-Layer AI Architecture                                             │
+│  (abstraction; CE = canonical realization)                           │
+├──────────────────────────────────────────────────────────────────────┤
+│                                                                      │
+│  Layer 1: Rules         always-loaded session context                │
+│  ─────────────          (compact pointers; behavioral guardrails)    │
+│  ai/claude-code/rules/*.md         (standards repo owns)             │
+│                                                                      │
+│  Layer 2: Workflow Skills    on-demand orchestrators                 │
+│  ────────────────────────    (compose into pipelines)                │
+│  templates/.claude/skills/   ←  vendor-neutral baseline              │
+│  CE skills (/ce-plan etc.)   ←  canonical realization                │
+│                                                                      │
+│  Layer 3: Persona Agents     skill-orchestrated personas             │
+│  ───────────────────────     (or directly invocable for simple)      │
+│  templates/.claude/agents/   ←  vendor-neutral baseline              │
+│  CE persona reviewers        ←  canonical realization                │
+│                                                                      │
+│  Layer 4: References         skill-loaded progressive context        │
+│  ───────────────────         (loaded during skill execution)         │
+│  CE skills' references/      ←  canonical realization                │
+│  (no vendor-neutral baseline yet — described in architecture)        │
+│                                                                      │
+│  Layer 5: Compound /          institutional knowledge accumulation   │
+│           Learnings           (feeds forward into future work)       │
+│  ───────────────────          (closes the learning loop)             │
+│  CE: docs/solutions/ +        ←  canonical realization               │
+│  ce-compound, ce-compound-refresh                                    │
+│  (no vendor-neutral baseline yet — described in architecture)        │
+│                                                                      │
+│  Layer 6: Hooks              deterministic non-AI enforcement        │
+│  ──────────────              (zero context cost)                     │
+│  templates/.claude/hooks/    (standards repo owns)                   │
+│                                                                      │
+└──────────────────────────────────────────────────────────────────────┘
+
+Pipelines compose Layer 2 skills:
+  brainstorm ──▶ plan ──▶ work ──▶ doc-review ──▶ code-review ──▶ compound
+                  │         │           │              │
+                  ▼         ▼           ▼              ▼
+              [Layer 4]  [Layer 4]  [Layer 3       [Layer 3
+              references references  personas]      personas]
+                                         │              │
+                                         └──────────────┴──▶ [Layer 5]
+                                                              compound
+```
+
+**Reading the model**: Layers are ordered by context-cost (Layer 1 always-loaded → Layer 6 zero-context). Each layer's slot is **independent** — a project can fill Layers 1, 4, 6 from the standards repo while filling Layers 2, 3, 5 from CE; or fill all six from CE; or fill 1, 2, 3, 6 from vendor-neutral templates with no Layer 4 or 5; etc.
+
+**The principle each layer specializes**:
+- Layer 1: persistence (load once per session, every session)
+- Layer 2: composability (workflows compose into pipelines)
+- Layer 3: perspective (multiple expertises analyze the same artifact)
+- Layer 4: progressivity (context grows as workflow depth grows, not at invocation)
+- Layer 5: compounding (institutional knowledge accumulates across work)
+- Layer 6: determinism (non-AI enforcement at the shell boundary)
+
+These six principles together capture *what makes LLM-based engineering work as practiced today*. The 4-layer captured three of them (persistence, composability, perspective) plus determinism; the 6-layer adds progressivity and compounding.
+
+---
+
+## Implementation Units
+
+8 units, dependency-ordered.
+
+- U1. **ADR — Establish the 6-layer AI architecture**
+
+**Goal:** Capture the architectural decision: 6-layer AI model as the abstraction, CE as canonical realization, vendor-neutrality preserved by the layering itself. Defend the model with the principle-per-layer framing. Establish the publication-quality framing for downstream artifacts (U2 onward).
+
+**Requirements:** R1, R11, R12
+
+**Dependencies:** None.
+
+**Files:**
+- Create: `docs/README.md` (one-paragraph stub: "this directory holds documentation per `process/documentation-standards.md`; current contents: `engineering/`, `plans/`")
+- Create: `docs/engineering/README.md` (one-paragraph stub pointing into `adr/` with a note that `designs/` would live here too when written)
+- Create: `docs/engineering/adr/0001-six-layer-ai-architecture.md`
+
+**Approach:**
+- Create the directory tree (`docs/`, `docs/engineering/`, `docs/engineering/adr/`). `docs/plans/` already exists.
+- Create the two README stubs to honor `process/documentation-standards.md` line 125.
+- Use the lightweight ADR format from `process/documentation-standards.md` lines 83–92 (Decision / Context / Consequences). Sections:
+  - **Decision**: adopt the 6-layer AI architecture; CE is canonical realization; vendor-neutral baselines stay in place.
+  - **Context**: PRs #16/#19/#21 shipped a 4-layer model; CE adoption surfaced structural patterns the 4-layer didn't name; three rounds of doc-review on the abandoned prior plan converged on this evolution.
+  - **The architecture — vendor-neutral description**: one paragraph per layer, naming the principle each specializes. Layer table: layer / principle / what fills it (vendor-neutral baseline + CE realization).
+  - **Why CE specifically as canonical realization**: short subsection. CE is the most developed implementation in active use across rmorison projects; describing the architecture in CE's terms gives concrete grounding while the layer definitions stay abstract enough that other realizations fit.
+  - **Consequences**: list what changes (Layer 4/5 named for the first time; Layer 1 stays pointers; vendor-neutral Layer 2/3 baselines unchanged; CE adoption is additive when present), what stays unchanged (PR-based merges, semver, conventional commits, code quality principles, the principle "context is expensive"), and the maintenance liability the architecture creates (track CE realization at major versions; revisit layer definitions when other LLM-engineering toolkits surface patterns we should absorb).
+  - **References**: rescoped issue #22, the integration doc (U2), PRs #16/#19/#21 (built on, not superseded), the three to-be-archived prior proposals, books-ops as private real-world deployment example.
+- Write the ADR with publication-quality framing. Reader assumption: a developer landing on the repo cold; no rmorison context. Layer definitions describe what the layer is structurally, not which CE skill fills it. The "vendor-neutral baseline + CE realization" framing makes the abstraction visible.
+- Number 0001; no ADRs exist yet.
+
+**Patterns to follow:**
+- ADR shape from `process/documentation-standards.md` lines 83–92.
+- Publication-quality framing: each layer description should answer "what is this layer for, structurally" before naming what fills it.
+
+**Test scenarios:**
+- Test expectation: none — documentation. Verification by structural review.
+
+**Verification:**
+- ADR exists at `docs/engineering/adr/0001-six-layer-ai-architecture.md`.
+- Six layers each have a paragraph of vendor-neutral structural description.
+- Each layer names its principle (persistence, composability, perspective, progressivity, compounding, determinism).
+- Layer table shows vendor-neutral baseline + CE realization side-by-side.
+- "Why CE specifically" subsection defends the canonical-realization choice without making CE sound mandatory.
+- Consequences distinguish "review discipline" from "enforced merge gate."
+- A reader without rmorison context can understand the architecture from the ADR alone.
+- `docs/README.md` and `docs/engineering/README.md` exist as minimal stubs.
+
+---
+
+- U2. **Rewrite `ai/claude-code/README.md` as canonical 6-layer description**
+
+**Goal:** The repo's load-bearing AI-architecture description for new adopters. Rewritten with publication-quality framing — readable as standalone document. Names the 6 layers, their principles, what fills each (vendor-neutral baseline + CE realization), and how the layers compose into pipelines.
+
+**Requirements:** R2, R11, R12
+
+**Dependencies:** U1 (references the ADR by number).
+
+**Files:**
+- Modify (substantial rewrite): `ai/claude-code/README.md`
+
+**Approach:**
+- **Section: Abstraction & Realization**: open with the framing — this directory describes the AI architecture; the architecture is the abstraction; CE is one canonical realization. Vendor-neutral baselines exist for some layers; non-CE adopters can use them or roll their own.
+- **Section: The Six Layers**: one subsection per layer. Each subsection has:
+  - Layer name and one-sentence principle (persistence / composability / perspective / progressivity / compounding / determinism)
+  - Structural description (what the layer holds, when it's loaded, what its constraints are)
+  - Vendor-neutral baseline (pointer to where it lives in the standards repo)
+  - CE realization (link to plugin and one-paragraph description of CE's implementation)
+  - Examples of other potential realizations (Cursor commands, Aider, hand-rolled — keeps the abstraction concrete without committing to those)
+- **Section: How the Layers Compose**: short subsection showing the pipeline pattern (brainstorm → plan → work → doc-review → code-review → compound) and how Layer 2 skills consume Layer 3 personas via Layer 4 references and produce Layer 5 compound output. Reference the High-Level Technical Design block from this plan as the visual aid.
+- **Section: How to Use**: brief; for this repo and for new projects (copy `templates/.claude/`).
+- **Section: Design Principles**: keep the existing principles ("Context is expensive — only load what's needed, when it's needed", "Standards are enforced, not just referenced", "Templates over copies", "Projects customize, templates provide structure"). They transfer cleanly to the 6-layer.
+- **Length target**: 100–150 lines. Compact enough to read in one sitting; rich enough to be a standalone architecture description.
+- Pointer at the bottom to the ADR (U1) and integration doc (U5).
+- Do NOT cite books-ops in this file.
+
+**Patterns to follow:**
+- Existing voice: concise, table-heavy, links-out-to-detail.
+- Publication-quality framing: structural before specific. A reader should understand the layer's *purpose* before seeing what fills it.
+
+**Test scenarios:**
+- Test expectation: none — documentation. Verification by structural review and reader test.
+
+**Verification:**
+- File describes 6 layers, each with principle + structural description + vendor-neutral baseline + CE realization + other-realization examples.
+- "How the Layers Compose" section explains pipelines.
+- A reader without rmorison context can understand the architecture from this file alone.
+- File length 100–150 lines.
+- Pointers to ADR and integration doc present.
+- No rmorison-specific assumptions or books-ops citations.
+
+---
+
+- U3. **Update `ai/CLAUDE.md` to reflect 6-layer architecture**
+
+**Goal:** `ai/CLAUDE.md` is the highest-leverage AI-facing artifact (agents read it every turn). Update it so an agent operating in CE-mode or standards-only-mode gets correct guidance without ambiguity. Keep the file functional as a template for downstream projects.
+
+**Requirements:** R3, R10, R13
+
+**Dependencies:** U1, U2 (file points at both).
+
+**Files:**
+- Modify: `ai/CLAUDE.md`
+
+**Approach:**
+- **Add an Architecture intro** (after the existing "For AI Assistants" header): one paragraph stating that this repo follows the 6-layer AI architecture (link to `ai/claude-code/README.md`) and that this file holds Layer 1-style guidance for CE-using projects.
+- **Reframe the Documentation Structure block** (lines ~54–66): two-mode block — "Standards-only mode" (existing tree) and "When CE is in use" (CE path-ownership table inlined from U5). Both visible.
+- **Reframe the Feature Development Workflow numbered list** (lines ~24–29): two-mode — standards-only list unchanged; CE-mode list (Phase 0 = `docs/brainstorms/`, Phase 1 seeded from brainstorm, Phase 3-4 outputs at CE-mode paths). Phase 0 = brainstorm declaration is R13.
+- **Reframe the branch-naming line** (line 41): two-mode — standards-only `{issue-number}-{slugified-title}`; when CE is in use, also accepts topic-style for `lfg`/`ce-work` flows without a parent issue. Pointer to integration doc.
+- **Add a "When using compound-engineering" section** at the end of the file: one-line precedence statement with provenance clause summary; one-paragraph framing of AI-review as discipline (not gate); pointers to ADR (U1) and integration doc (U5).
+- Update the Quick Links section to include the new ADR and integration doc.
+- Do NOT cite books-ops.
+
+**Patterns to follow:**
+- Existing `ai/CLAUDE.md` voice — terse, tables, link-out.
+
+**Test scenarios:**
+- Test expectation: none — documentation. Verification per the next field.
+
+**Verification:**
+- Architecture intro present and points at `ai/claude-code/README.md`.
+- Documentation Structure block has explicit standards-only and CE-mode sub-blocks.
+- Feature Development Workflow list shows both modes; Phase 0 = brainstorm declared.
+- Branch-naming line carries both rules with CE carve-out qualified explicitly.
+- "When using compound-engineering" section present at end.
+- Pointers to ADR and integration doc in body and Quick Links.
+- An agent reading the file top-down does not encounter a contradicted rule.
+
+---
+
+- U4. **Update Layer 1 rule files (`ai/claude-code/rules/*.md`) — compact CE-aware additions**
+
+**Goal:** Layer 1 files are always-loaded; their content shapes default agent behavior every turn. Add CE-aware notes that point at the integration doc when CE is in use, **without inlining two-mode policy** (preserves Layer 1's compact-pointer discipline).
+
+**Requirements:** R4, R10, R13
+
+**Dependencies:** U1, U5.
+
+**Files:**
+- Modify: `ai/claude-code/rules/engineering-standards.md`
+- Modify: `ai/claude-code/rules/sdlc-workflow.md`
+
+**Approach:**
+
+For **`ai/claude-code/rules/engineering-standards.md`**:
+- After the `docs/` tree block (lines 27–37), add ONE paragraph: "When compound-engineering is in use, additional artifact paths apply (`docs/brainstorms/`, `docs/plans/`, `docs/solutions/`). See `process/compound-engineering-integration.md` for the full path mapping and precedence rules."
+- After the Branch-naming line (line 44), add ONE line: "When CE is in use, `lfg`/`ce-work` autonomous flows may produce topic-style branches; see `process/git-branching-strategy.md` and the integration doc."
+- Do NOT replace existing rules with two-mode blocks; do NOT reframe the Quick Reference structurally. Layer 1's discipline is compact-pointer; the additions are pointers.
+
+For **`ai/claude-code/rules/sdlc-workflow.md`**:
+- After the "Plan Before Implementing" section (lines 13–18), add ONE paragraph: "When compound-engineering is in use, `/ce-plan` produces the plan and `/ce-work` executes it iteratively; the `lfg` autonomous flow runs without per-step confirmation and is appropriate when a complete plan exists. See `process/compound-engineering-integration.md` for the workflow."
+- Other sections (Read Before Changing, Validate After Each Change, Flag Uncertainty, Scope Discipline) are CE-compatible; no changes.
+
+**Verify post-edit line counts**: target both files staying at or under 80 lines (well within the 150-line discipline). Each addition should be ≤ 5 lines.
+
+**Patterns to follow:**
+- Existing terse voice. Pointer-style: state the rule, link to the elaboration.
+
+**Test scenarios:**
+- Test expectation: none — documentation. Verification per the next field.
+
+**Verification:**
+- `ai/claude-code/rules/engineering-standards.md` has CE-aware additions after `docs/` tree and after branch-naming line; total file length ≤ 80 lines.
+- `ai/claude-code/rules/sdlc-workflow.md` has a CE-aware addition after Plan Before Implementing; total file length ≤ 60 lines.
+- Both files retain their compact-pointer character; no inlined two-mode policy.
+- Pointers to `process/compound-engineering-integration.md` work.
+
+---
+
+- U5. **Write integration process doc — CE realization of the 6 layers + operational details**
+
+**Goal:** Operational reference that describes how CE realizes the 6-layer architecture and resolves the path conflicts, branch-naming reconciliation, AI-review discipline, and ticket-tracking modes. Self-contained — load-bearing content inlined.
+
+**Requirements:** R5, R10, R11, R13
+
+**Dependencies:** U1.
+
+**Files:**
+- Create: `process/compound-engineering-integration.md`
+
+**Approach:**
+- **Header**: scope statement, audience ("projects using compound-engineering — concretely the rmorison projects, but the integration is intended to be readable and usable by any adopter"), and the precedence rule with provenance clause (R13).
+- **Section 1: How CE realizes the 6 layers**: brief table mapping layer → CE realization. Cross-reference `ai/claude-code/README.md` (U2) for the canonical layer descriptions; this section is the operational mapping.
+  - Layer 1: standards repo (CE doesn't fill)
+  - Layer 2: CE skills (`/ce-brainstorm`, `/ce-plan`, `/ce-work`, `/ce-doc-review`, `/ce-code-review`, `/ce-debug`, `/ce-compound`, `lfg`)
+  - Layer 3: CE persona reviewers (~20 specialized agents, dispatched by Layer 2 skills)
+  - Layer 4: CE skills' `references/*.md` subtrees
+  - Layer 5: `docs/solutions/` + `ce-compound`/`ce-compound-refresh`
+  - Layer 6: standards repo (CE doesn't fill)
+- **Section 2: Artifact location mapping**: full path table including `docs/solutions/` row. Inline the table directly (do NOT point at books-ops):
+
+  | Path | Owner | Producer |
+  | --- | --- | --- |
+  | `docs/ideation/` | CE | `ce-ideate` |
+  | `docs/brainstorms/` | CE | `ce-brainstorm` — also Phase 0 / discovery artifact for `process/feature-development-workflow.md`; Phase 1 seeded from brainstorm |
+  | `docs/plans/` | CE | `ce-plan` (subsumes `docs/planning/` from the standards) |
+  | `docs/solutions/` | CE | `ce-compound`, `ce-compound-refresh` (Layer 5; no standards analog yet) |
+  | `docs/engineering/adr/` | shared | human-authored ADRs (path identical in both models) |
+  | `docs/engineering/designs/` | standards | human-authored design docs |
+  | `docs/product/` | standards | human-authored product concepts and feature specs |
+
+  State the precedence rule + provenance clause: when a CE skill produces an artifact, CE paths and conventions win; standards paths/conventions own human-authored artifacts; first-skill-touched-the-file is the default; explicit `provenance:` frontmatter overrides.
+
+- **Section 3: Issue-tracking modes**: three modes — team-scale (full three-tier hierarchy from `process/issue-tracking.md`), solo + AI (reactive issue creation, plan U-IDs as unit tracker), hybrid. Cite the existing solo carve-outs in `process/issue-tracking.md` lines 359–373. Inline a minimal Ticket Policy block (umbrella epic per multi-phase plan, sub-issues reactive, U-aligned branch naming).
+
+- **Section 4: Branch-naming reconciliation**: issue-numbered when an issue exists, topic-style for `lfg`/`ce-work` flows without a parent issue. Pointer to U7's anti-pattern reframe in `process/git-branching-strategy.md`.
+
+- **Section 5: Solo-scale adaptations + AI-review discipline**: what shifts at solo scale (no planning poker; no human code-review assignment; milestones earn keep at >3-month horizons; epic structure earns keep at 5+ implementation issues per feature).
+  - **AI-review discipline**: explicit framing — this is **review discipline**, not an enforced merge gate. No CI check, branch-protection automation, or PR template enforces it. The discipline names: (a) `ce-code-review` on the diff before merge; (b) `ce-doc-review` on the plan or spec when applicable; (c) self-review against plan acceptance criteria. **Failure modes the discipline does not catch**: cross-PR scope drift, self-grading loops, product-positioning regressions, same-intent author/reviewer. When a human reviewer onboards, the standards' "Require at least 1 approval" rule re-engages and AI review becomes complementary.
+
+- **Section 6: CE skill ↔ standards doc cross-reference**: table mapping each CE skill (workflow + behavior description) to the standards docs it operates within. Behavior described alongside skill name to localize name-churn rot.
+
+- **Footer: Real-world deployment example**: one paragraph naming `books-ops` as a private rmorison deployment that informed this doc's wording. No line-range citations; no references to books-ops content as canonical.
+
+**Patterns to follow:**
+- `process/issue-tracking.md` voice for the issue-tracking section.
+- `process/git-branching-strategy.md` voice for the branch-naming section.
+
+**Test scenarios:**
+- Test expectation: none — documentation. Verification per the next field.
+
+**Verification:**
+- All six sections present.
+- Layer-to-CE-realization mapping includes all 6 layers.
+- Documentation Paths table inlined directly (not linked to books-ops).
+- Precedence rule + provenance clause stated.
+- AI-review discipline section names: (a) what's checked, (b) the four failure modes, (c) explicit "discipline, not enforced gate" framing.
+- Ticket Policy block inlined.
+- `books-ops` named only in the footer as real-world deployment.
+- A reader without rmorison repo access can apply the doc end-to-end.
+- No team-scale standards weakened — every cross-reference is additive.
+
+---
+
+- U6. **Rewrite README's "AI / Claude Code Integration" section + add Process Standards entry**
+
+**Goal:** Front-door positioning. The README is where readers land first; it must reflect the 6-layer architecture and name CE as canonical realization without losing the lightweight-standards positioning.
+
+**Requirements:** R6, R10, R11
+
+**Dependencies:** U1, U2, U5.
+
+**Files:**
+- Modify: `README.md`
+
+**Approach:**
+- **Replace** the "AI / Claude Code Integration" section (lines 96–117) with a CE-aware 6-layer version:
+  - One-paragraph intro: this repo defines a 6-layer AI architecture (link to `ai/claude-code/README.md`); CE is named as canonical realization for projects that adopt the plugin.
+  - **Layer table** (replacing the existing 4-row table): six rows, one per layer, with: Layer name / Principle / Vendor-neutral baseline / CE realization. Brief — link out to `ai/claude-code/README.md` for full descriptions.
+  - **"Key principle" line**: keep the existing "Context is expensive — only load what's needed, when it's needed." It transfers cleanly. Add: "The 6-layer model specializes this principle across context-cost slots."
+- **Add** a Process Standards entry for `process/compound-engineering-integration.md` between the existing Issue Tracking section and the AI / Claude Code Integration section. One paragraph, ≤ 4 lines.
+- **Add** one line under "Applying These Standards" → "For New Projects" noting that projects using CE consult the integration doc for Layer 2/3 path mapping and review discipline.
+- Do not restructure other sections.
+
+**Patterns to follow:**
+- Existing README voice.
+
+**Test scenarios:**
+- Test expectation: none — documentation. Verification per the next field.
+
+**Verification:**
+- README "AI / Claude Code Integration" section reflects 6-layer model with vendor-neutral baseline + CE realization columns.
+- "Key principle: context is expensive" preserved and extended.
+- Process Standards entry for the integration doc present.
+- "Applying These Standards" includes CE pointer.
+- A reader landing on the README sees the architecture before any specific workflow rule.
+
+---
+
+- U7. **Update `process/git-branching-strategy.md` — anti-pattern carve-out + Layer 3 discipline cross-ref + pointer**
+
+**Goal:** Address the genuine conflict between standards' issue-required branch naming and CE's `lfg`/`ce-work` autonomous flows. Add a Layer 3 discipline cross-ref in branch protection.
+
+**Requirements:** R8, R10, R13
+
+**Dependencies:** U5.
+
+**Files:**
+- Modify: `process/git-branching-strategy.md`
+
+**Approach:**
+- **Edit the "❌ Branches Without Issues" anti-pattern** (lines 287–291): add a one-line carve-out — "*Exception: `lfg` and `ce-work` autonomous flows may produce topic-style branches (`feat/...`, `fix/...`) without a parent issue. File an issue retroactively only if review surfaces something worth tracking. See `process/compound-engineering-integration.md`.*"
+- **Add a "When using compound-engineering" pointer** near the top of the file (after the Overview): one-line note with link to integration doc.
+- **Add a Layer 3 discipline cross-ref to the Branch Protection block** (lines 322–331): one-line note that the "Require at least 1 approval" rule has a CE-mode complement — the Layer 3 AI-review discipline (`ce-code-review` + `ce-doc-review`), defined in the integration doc. Frame as discipline, not enforced gate.
+- Do not rewrite the GitHub Flow guidance.
+
+**Patterns to follow:**
+- Existing voice/formatting.
+
+**Test scenarios:**
+- Test expectation: none — documentation. Verification per the next field.
+
+**Verification:**
+- Anti-pattern carve-out present and points at the integration doc.
+- Cross-ref pointer present near the top.
+- Branch protection block carries the Layer 3 discipline cross-ref — preserves team-scale rule, adds CE complement, framed as discipline not enforced gate.
+
+---
+
+- U8. **Cross-references in remaining 4 process docs + archive 3 prior `ai/*.md` proposals**
+
+**Goal:** Complete the cross-reference work and archive the genuine path-not-taken (the three pre-CE agent-native proposals).
+
+**Requirements:** R8, R9, R10, R13
+
+**Dependencies:** U1, U5.
+
+**Files:**
+- Modify: `process/feature-development-workflow.md` (Phase 0 = brainstorm note in or near Phase 1 block, lines 40–70)
+- Modify: `process/issue-tracking.md` (cross-ref pointer near Three-Tier Hierarchy section, citing existing solo carve-outs at lines 359–373)
+- Modify: `process/project-planning-standards.md` (cross-ref pointer near Team Estimation section, citing existing solo carve-out at line 86)
+- Modify: `process/documentation-standards.md` (cross-ref note in or near Directory Structure, lines 9–47)
+- Move: `ai/adoption-roadmap.md` → `archive/adoption-roadmap.md`
+- Move: `ai/agent-native-improvements.md` → `archive/agent-native-improvements.md`
+- Move: `ai/top-3-enhancements.md` → `archive/top-3-enhancements.md`
+- Create: `archive/README.md` (short explainer for the archived proposals)
+
+**Approach:**
+
+Cross-references (each is 1–3 lines, additive, points at `process/compound-engineering-integration.md`):
+- **`process/feature-development-workflow.md`**: in or just before Phase 1, add note that `docs/brainstorms/<topic>-requirements.md` (the `ce-brainstorm` output) IS the Phase 0 / discovery artifact when CE is in use; Phase 1 is seeded from the brainstorm.
+- **`process/issue-tracking.md`**: near Three-Tier Hierarchy, add pointer with citation to existing solo carve-outs at lines 359–373.
+- **`process/project-planning-standards.md`**: near Team Estimation, add pointer noting that for solo CE work, point estimates in plan files serve as self-calibration; planning poker is N/A. Cite the existing solo carve-out at line 86.
+- **`process/documentation-standards.md`**: near Directory Structure, add note that CE-skill outputs live at `docs/brainstorms/`, `docs/ideation/`, `docs/plans/`, `docs/solutions/` per the integration doc's path mapping.
+
+Archive (3 prior proposals, currently untracked per `git status`):
+- `git mv` would fail on untracked files. Use: `mkdir -p archive && mv ai/<file>.md archive/<file>.md`, then `git add archive/`. The archival commit is these files' first appearance in history.
+- Banner each archived file (relative path `../docs/engineering/adr/...`):
+  ```
+  > **Implementation strategy superseded by [ADR-0001: Six-Layer AI Architecture](../docs/engineering/adr/0001-six-layer-ai-architecture.md).**
+  >
+  > This document analyzed agent-native principles and proposed building these abstractions in this repo. We instead adopted the 6-layer AI architecture (this ADR) with [compound-engineering](https://github.com/EveryInc/compound-engineering-plugin) as the canonical realization of Layers 2 and 3. Kept here as the evaluative framework that informed the architecture — the analysis remains the lens for re-evaluating CE adoption if circumstances change. See `process/compound-engineering-integration.md` for the operational doc.
+  ```
+- `archive/README.md`: short explainer (one paragraph) describing the three archived docs as the agent-native-analysis path-not-taken; names the architecture chosen instead.
+
+**Patterns to follow:**
+- Existing voice/format in each file.
+- Match existing cross-ref style.
+
+**Test scenarios:**
+- Test expectation: none — documentation. Verification per the next field.
+
+**Verification:**
+- All four named process docs have a CE cross-ref.
+- Phase 0 = brainstorm note exists in `process/feature-development-workflow.md` (R13).
+- Solo-mode pointer in `process/issue-tracking.md` cites existing carve-outs (R10: not weakening).
+- Planning poker N/A note in `process/project-planning-standards.md` cites the existing solo carve-out.
+- Three `ai/*.md` proposals exist at `archive/<name>.md`, with banners and working ADR links.
+- `archive/README.md` exists.
+- Recursive globs against `ai/**/*.md` no longer return the archived content.
+- `templates/.claude/skills/`, `templates/.claude/agents/`, `templates/.claude/hooks/`, `templates/.claude/settings.json` UNCHANGED (vendor-neutral baselines stay in place).
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** AI agents reading `ai/CLAUDE.md` (U3) get architecture pointers. The integration doc (U5) is the load-bearing operational reference. Layer 1 rules (U4) carry pointer-only notes; multi-mode policy lives in U3 and U5. The README (U6) and `ai/claude-code/README.md` (U2) frame the architecture for human and AI readers respectively. Cross-refs in U7 and U8 are signposts back to U5.
+- **Error propagation:** N/A — documentation change. The architectural framing's failure mode is "reader misinterprets the layering"; mitigation is publication-quality framing (R11) with reader-test verification.
+- **State lifecycle risks:** None — no runtime state.
+- **API surface parity:** N/A — no APIs.
+- **Integration coverage:** "No team-scale standards weakened" (R10) requires re-reading every cross-ref in U7/U8 to verify additive language.
+- **Unchanged invariants:** ADR location convention; semver; conventional commits; PR-based merges; GitHub Flow; code quality principles; documentation formats; the vendor-neutral templates' Layer 2 and Layer 3 baselines (`templates/.claude/skills/`, `templates/.claude/agents/`); the 4-layer model's principle ("context is expensive — only load what's needed, when it's needed") — preserved and extended.
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| 6-layer model is novel; layer definitions may need refinement once real adopters use them. | Publication-quality framing (R11) gives the architecture a chance to be tested by external readers (the article surface). Iteration is expected post-merge; the architecture is live documentation, not a final claim. |
+| Layer 4 (References) and Layer 5 (Compound) currently have only CE realizations. Vendor-neutral baselines for these layers don't exist yet. | The architecture describes what those layers ARE structurally; the lack of vendor-neutral baseline is named honestly ("no vendor-neutral baseline yet — described in architecture"). Future work could populate these layers in `templates/`. |
+| Integration doc's "AI-review discipline" framing is misread as enforced gate, leading to false confidence. | Doc explicitly frames as "process discipline, not enforced by repo configuration." Failure modes named explicitly. Adopters know what they're trading. |
+| Vendor coupling at Layer 2/3 (CE) creates a maintenance liability against EveryInc's roadmap. | ADR (U1) defends the canonical-realization choice and states the upgrade discipline (pin to CE 3.x; re-evaluate at 4.x). Layer 2/3 vendor-neutral baselines remain in place; CE adoption is opt-in. |
+| Single-PR scope (~500–700 lines / ~12–14 files) above standards' 200-400 target. | Standards' "When to Deviate" provision covers branching-model alternatives, not PR size — so the deviation must stand on cross-reference coherence (artifacts reference each other). Split is available if review surfaces seams (U1+U2 first; everything else follows). |
+| Publication-quality framing (R11) adds drafting latency. | The latency is the cost of the publication-quality bar. ce-doc-review (run after plan write) provides a reader-quality gate. Iteration cost is bounded. |
+| Books-ops privacy: integration doc inlines content, but books-ops is named in the footer as real-world deployment. | Footer is one paragraph; no line-range citations; integration doc is self-contained. A non-rmorison reader hits "this is private" once and proceeds. |
+| Three rounds of doc-review on the abandoned plan converged on the 6-layer; this plan should not need 3 more rounds. | Plan written tighter than the abandoned one; key architectural decisions (6-layer, vendor-neutral baselines stay, Layer 1 stays compact) decided up-front. ce-doc-review is the next quality gate; results from that pass should be substantively different than rounds 1–3 of the prior plan because the architectural framing is now sound. |
+
+---
+
+## Documentation / Operational Notes
+
+- **After merge**: notify books-ops to refresh its CLAUDE.md to point at the published integration doc instead of the in-flight #22 reference. Books-ops' `CLAUDE.md` already says "see engineering-standards#22 for the in-flight upstream proposal" in two places; those become "see `process/compound-engineering-integration.md`." books-ops can also drop its locally-absorbed Documentation Paths table since the integration doc carries it canonically.
+- **Issue #12** (Phase 0): R13 partially addresses for CE-mode adopters. Verify acceptance language before closing.
+- **Issues #16/#19/#21**: built on, not superseded. Optional one-line comments noting the architecture has evolved (cheap to add post-merge if discoverability becomes a concern).
+- **PR description**: lead with the architectural framing (6-layer abstraction + CE as canonical realization). The framing is the central contribution; surfacing it in the description helps reviewers understand the structural choice before evaluating individual file diffs. Invoke standards' "When to Deviate" only if PR size is questioned; the cross-reference coherence argument stands on its own.
+- **No CI changes, no migrations, no runtime impact**. Pure documentation and three file relocations.
+- **Branch rename** (deferred to implementation): if the implementer prefers the branch name to match the new title, `git branch -m 22-refactor-ai-architecture-6-layer-model` and `git push -u origin 22-refactor-ai-architecture-6-layer-model` mid-PR. Not required.
+
+---
+
+## Sources & References
+
+- **Origin issue:** [rmorison/engineering-standards#22 (rescoped)](https://github.com/rmorison/engineering-standards/issues/22) — "Refactor AI architecture to a 6-layer model with compound-engineering as canonical realization"
+- **Prior plan (abandoned):** [`docs/plans/2026-05-03-001-feat-compound-engineering-integration-plan.md`](2026-05-03-001-feat-compound-engineering-integration-plan.md) — three rounds of doc-review iteration; operational findings carried forward (R13)
+- **Built on:** PRs [#16](https://github.com/rmorison/engineering-standards/issues/16) (4-layer AI architecture), [#19](https://github.com/rmorison/engineering-standards/issues/19) (README documentation), [#21](https://github.com/rmorison/engineering-standards/issues/21) (PascalCase hooks). The 4-layer was the foundation this evolves.
+- **Related issue:** [#12](https://github.com/rmorison/engineering-standards/issues/12) (Phase 0) — partially addressed by R13 for CE-mode adopters.
+- **CE plugin:** https://github.com/EveryInc/compound-engineering-plugin (v3.1.0; canonical realization of Layers 2, 3, 4, 5)
+- **Agent-native foundation:** https://every.to/guides/agent-native (informed both the original 4-layer and CE itself)
+- **Real-world deployment example:** `books-ops` (private rmorison repo) — informed wording during real use of the brainstorm → plan → ce-doc-review → lfg pipeline. Not a doc reference; integration doc is self-contained.
+- **Memory:** `architecture_explanation_style.md`, `ce_as_engineering_baseline.md`, `repo_purpose_and_article.md` (in `~/.claude/projects/.../memory/`)
+- **Affected files:** `docs/README.md` (new), `docs/engineering/README.md` (new), `docs/engineering/adr/0001-six-layer-ai-architecture.md` (new), `process/compound-engineering-integration.md` (new), `archive/README.md` (new), `ai/claude-code/README.md`, `ai/CLAUDE.md`, `ai/claude-code/rules/engineering-standards.md`, `ai/claude-code/rules/sdlc-workflow.md`, `templates/CLAUDE.md`, `README.md`, `process/feature-development-workflow.md`, `process/issue-tracking.md`, `process/project-planning-standards.md`, `process/documentation-standards.md`, `process/git-branching-strategy.md`, three archived `ai/*.md` files (moves)

--- a/docs/plans/2026-05-03-002-refactor-ai-architecture-6-layer-model-plan.md
+++ b/docs/plans/2026-05-03-002-refactor-ai-architecture-6-layer-model-plan.md
@@ -1,8 +1,9 @@
 ---
 title: "refactor: Adopt 6-layer AI architecture with compound-engineering as canonical realization"
 type: refactor
-status: active
+status: completed
 date: 2026-05-03
+completed: 2026-05-03
 origin: https://github.com/rmorison/engineering-standards/issues/22
 prior_plan: docs/plans/2026-05-03-001-feat-compound-engineering-integration-plan.md
 ---

--- a/process/compound-engineering-integration.md
+++ b/process/compound-engineering-integration.md
@@ -1,0 +1,174 @@
+# Compound Engineering Integration
+
+*Operational reference for adopting compound-engineering as the canonical realization of Layers 2–5 of the [six-layer AI architecture](../ai/claude-code/README.md).*
+
+**Architectural decision:** [ADR-0001](../docs/engineering/adr/0001-six-layer-ai-architecture.md).
+**Audience:** projects using compound-engineering (CE) — most concretely the `rmorison` projects, but the integration is intended to be readable and usable by any adopter.
+**Status:** active.
+
+---
+
+## Scope
+
+This document describes how compound-engineering ([CE](https://github.com/EveryInc/compound-engineering-plugin), v3.x) realizes the six-layer AI architecture in the engineering-standards repository, and resolves the operational details that surface when CE coexists with these standards: artifact path conventions, issue-tracking ceremony scaling, branch-naming reconciliation, AI-review discipline, and ticket-tracking modes.
+
+For the architecture itself, see [`ai/claude-code/README.md`](../ai/claude-code/README.md). This doc is the operational complement.
+
+**Precedence rule with provenance clause.** When a CE skill produces an artifact, CE paths and conventions win. Standards paths and conventions own human-authored artifacts and ADRs. Edge cases:
+
+- **First-skill-touched-the-file wins** by default. If `ce-plan` produced `docs/plans/foo.md`, subsequent human edits do not reclassify it as hand-authored.
+- **Explicit reclassification** via a one-line `provenance:` frontmatter note (`provenance: hand-authored` or `provenance: ce-plan`) when the default rule produces the wrong answer.
+
+---
+
+## 1. How CE realizes the six layers
+
+| # | Layer | Principle | What CE provides |
+|---|-------|-----------|------------------|
+| 1 | Rules | Persistence | *Not provided.* The standards repo's [`ai/claude-code/rules/*.md`](../ai/claude-code/rules/) retains ownership. Rule files carry one-line CE-aware pointers, not multi-mode policy. |
+| 2 | Workflow Skills | Composability | ~30 skills covering discovery, planning, execution, review, debugging, and compounding. Pipeline shape: `ce-brainstorm → ce-plan → ce-work → ce-doc-review → ce-code-review → ce-compound`. The `lfg` skill runs the pipeline autonomously. |
+| 3 | Persona Agents | Perspective | ~20 specialized review personas dispatched in parallel by `ce-doc-review` and `ce-code-review` skills. Persona names are stable in CE 3.x. |
+| 4 | References | Progressivity | Each skill ships a `references/*.md` subtree loaded progressively as workflow depth grows. The pattern keeps Layer 2 skills lean at the entry point. |
+| 5 | Compound / Learnings | Compounding | `ce-compound` captures learnings from completed work into `docs/solutions/`. `ce-compound-refresh` audits and consolidates. The compound output is itself a Layer 5 artifact. |
+| 6 | Hooks | Determinism | *Not provided.* The standards repo's [`templates/.claude/hooks/`](../templates/.claude/hooks/) retains ownership. CE-mode invariants (e.g., warn if `/plan` is invoked instead of `/ce-plan`) can be added as hooks in follow-up work. |
+
+For the canonical layer descriptions (vendor-neutral), see [`ai/claude-code/README.md`](../ai/claude-code/README.md). This table is the operational mapping.
+
+---
+
+## 2. Artifact location mapping
+
+CE-using projects produce artifacts at paths the standards' `docs/` taxonomy does not name. The precedence rule (above) governs ownership; this table documents which paths are produced by which CE skill.
+
+| Path | Owner | Producer / notes |
+|------|-------|------------------|
+| `docs/ideation/` | CE | `ce-ideate` output |
+| `docs/brainstorms/` | CE | `ce-brainstorm` output. **Also serves as the Phase 0 / discovery artifact** for [`process/feature-development-workflow.md`](./feature-development-workflow.md); Phase 1 (Product Concept) is seeded from the brainstorm requirements doc. |
+| `docs/plans/` | CE | `ce-plan` output. Subsumes the standards' `docs/planning/` for CE-using projects. |
+| `docs/solutions/` | CE | Layer 5 artifacts produced by `ce-compound` and `ce-compound-refresh`. No standards analog yet. |
+| `docs/engineering/adr/` | shared | Human-authored ADRs. Path identical in standards-mode and CE-mode. |
+| `docs/engineering/designs/` | standards | Human-authored technical design documents. |
+| `docs/product/` | standards | Human-authored product concepts and feature specs. |
+
+**When in doubt:** if a CE skill produced the file, CE owns it. If a human authored it, standards conventions apply. The `provenance:` frontmatter override is available when the default heuristic produces the wrong answer.
+
+---
+
+## 3. Issue-tracking modes
+
+[`process/issue-tracking.md`](./issue-tracking.md) describes a three-tier hierarchy (Milestone → Epic → Implementation Issue) sized for 3–5-person teams managing multi-month initiatives. CE-using projects often work at smaller scales where the full ceremony exceeds value.
+
+Three modes apply:
+
+### Team-scale (default)
+
+Full three-tier hierarchy per [`process/issue-tracking.md`](./issue-tracking.md). Apply when:
+
+- Multiple contributors coordinating on a multi-month initiative
+- Stakeholder review cadence requires explicit milestone tracking
+- Cross-team dependencies require visible epic structure
+
+### Solo + AI
+
+Reactive issue creation only. The plan file (`docs/plans/...`) is the granular unit tracker via U-IDs; pre-allocating per-U sub-issues duplicates state and drifts from the plan. Apply when:
+
+- Sole contributor working with CE
+- Plan U-IDs adequately track granular progress
+- Issues created reactively for: `lfg` residuals, post-ship bugs, plan Open Question activations, scope expansions
+
+The standards' [`process/issue-tracking.md`](./issue-tracking.md) already carries solo carve-outs at lines 359–373 ("<3 issues: probably doesn't need an epic, just use labels"; "<1 month: might not need epic structure"). Solo + AI mode is the natural extension of those carve-outs.
+
+### Hybrid (solo today, team tomorrow)
+
+Adopt solo + AI mode now; introduce epics and milestones when a second contributor arrives or a multi-month initiative emerges. The transition is incremental: existing plan U-IDs become epic sub-issues; new work follows team-scale ceremony.
+
+### Ticket policy at solo + AI scale
+
+A minimal pattern that has worked in real use:
+
+- **One umbrella epic per multi-phase plan** (label: `epic`). The epic links to the plan; the plan is the granular tracker via U-IDs. Do not pre-allocate per-U sub-issues.
+- **Sub-issues are reactive**, filed when needed: `bug`, `from-review` (review residuals), `from-deferred-q` (Open Question activations), `tech-debt`, `enhancement`. Add `blocked` when waiting on a dependency.
+- **Branch naming** follows § 4 below.
+- **Skip:** milestones, point/size labels, theme labels. Use the plan, not GitHub metadata, to express phase + scope.
+
+---
+
+## 4. Branch-naming reconciliation
+
+[`process/git-branching-strategy.md`](./git-branching-strategy.md) prescribes `{issue-number}-{slugified-title}` and lists "❌ Branches Without Issues" as an anti-pattern. CE's `lfg` and `ce-work` autonomous flows can produce substantial work without a pre-existing issue.
+
+**Rule.** When an issue exists, use the standards' `{issue-number}-{slugified-title}` format. When `lfg` or `ce-work` produces a branch without a parent issue, topic-style naming (`feat/...`, `fix/...`, `refactor/...`) is acceptable. File an issue retroactively only if review surfaces something worth tracking.
+
+[`process/git-branching-strategy.md`](./git-branching-strategy.md) carries this carve-out in its anti-pattern section.
+
+---
+
+## 5. Solo-scale adaptations and AI-review discipline
+
+### Solo-scale adaptations
+
+What shifts at solo + AI scale, with citations to existing standards:
+
+- **Estimation.** [`process/project-planning-standards.md`](./project-planning-standards.md) line 86 already permits solo estimation. For CE-using solo work, point estimates in CE plan files (`docs/plans/...`) serve as the self-calibration mechanism; planning poker is N/A.
+- **Code review.** Standards assume a human reviewer. Solo + AI work substitutes the AI-review discipline below.
+- **Milestones.** Earn their keep at >3-month horizons. Solo + AI work over shorter horizons typically uses plans (Layer 2 outputs) and reactive issues.
+- **Epic structure.** Earns its keep at 5+ implementation issues per feature. Below that, plan U-IDs are the unit tracker.
+
+### AI-review discipline (not enforced merge gate)
+
+For solo + AI work, the human-reviewer slot in branch protection is replaced by an **AI-review discipline**. This is **process discipline, not a merge gate enforced by repo configuration**. There is no CI check, branch-protection automation, or PR template that enforces "no unresolved P0/P1 findings" — claiming otherwise would be aspirational documentation.
+
+**The discipline names:**
+
+1. **`ce-code-review`** on the diff before merge. Dispatches Layer 3 persona reviewers (security, reliability, performance, language-specific style, etc.) per the conditional triggers in the skill. Surfaces P0/P1 findings.
+2. **`ce-doc-review`** on the plan or spec when applicable. Dispatches Layer 3 persona reviewers (coherence, feasibility, scope-guardian, adversarial, product-lens, etc.). Surfaces P0/P1 findings.
+3. **Self-review against plan acceptance criteria.** The implementer verifies the unit's `Verification` field is satisfied before merge.
+
+**Failure modes the discipline does not catch:**
+
+- **Cross-PR scope drift.** AI reviewers see one diff at a time; missing requirements that span PRs are not flagged.
+- **Self-grading loops.** In solo mode the implementer decides what "unresolved" means. A P1 finding the implementer disagrees with becomes "addressed" by judgment.
+- **Product-positioning regressions.** AI reviewers tuned for code patterns miss strategic intent.
+- **Same-intent author/reviewer.** No second pair of eyes with independent stakes.
+
+Adopters who follow the discipline understand they are trading these failure modes for the speed of solo work. When a human reviewer onboards, the standards' "Require at least 1 approval" rule re-engages and AI review becomes complementary.
+
+[`process/git-branching-strategy.md`](./git-branching-strategy.md) carries a one-line note in its branch protection block pointing at this discipline.
+
+---
+
+## 6. CE skill ↔ standards doc cross-reference
+
+The table below maps each CE skill (Layer 2) to the standards doc(s) it operates within. Behavior is described alongside the skill name so that skill renaming within CE 3.x is a one-row table edit.
+
+| CE skill | Behavior | Standards doc(s) it operates within |
+|----------|----------|------------------------------------|
+| `ce-ideate` | Open-ended ideation; produces `docs/ideation/` artifacts | Pre-Phase 1 of [`process/feature-development-workflow.md`](./feature-development-workflow.md) |
+| `ce-brainstorm` | Structured requirements gathering; produces `docs/brainstorms/<topic>-requirements.md` | **Phase 0** of [`process/feature-development-workflow.md`](./feature-development-workflow.md); Phase 1 is seeded from the brainstorm output |
+| `ce-plan` | Produces implementation plans at `docs/plans/...` with U-IDs and acceptance criteria | Phases 3–4 of [`process/feature-development-workflow.md`](./feature-development-workflow.md); subsumes `docs/planning/` for CE-using projects |
+| `ce-work` | Executes a plan; manages task state and incremental commits | Phase 5 of [`process/feature-development-workflow.md`](./feature-development-workflow.md) |
+| `ce-doc-review` | Dispatches Layer 3 persona reviewers against a plan or requirements doc; produces P0–P3 findings | Phase 4 review surface (plans, designs, ADRs) |
+| `ce-code-review` | Dispatches Layer 3 persona reviewers against a code diff; produces P0–P3 findings | Phase 5 review surface (code review, the AI-review discipline above) |
+| `ce-debug` | Systematic root-cause investigation; produces a debug record | Bug-fix work in [`process/technical-work-workflow.md`](./technical-work-workflow.md) |
+| `ce-compound` | Captures learnings from completed work into `docs/solutions/` (Layer 5 output) | Phase 6 (validation/iteration) of [`process/feature-development-workflow.md`](./feature-development-workflow.md), or post-incident |
+| `ce-compound-refresh` | Audits and consolidates `docs/solutions/`; supersedes outdated learnings | Maintenance of Layer 5 artifacts |
+| `lfg` | Runs the brainstorm → plan → work → review → compound pipeline autonomously | The full feature workflow, executed without per-step confirmation |
+
+**Skill renaming.** CE skill names are stable in 3.x; if a skill renames, only this table changes. Behavior descriptions are the durable anchor.
+
+---
+
+## Real-world deployment example
+
+This integration doc was informed by `books-ops`, a private `rmorison` repository that ran the full `ce-brainstorm → ce-plan → ce-doc-review → lfg` pipeline against a real workload. The wording of the layer-realization mapping, the Ticket Policy block, and the AI-review discipline framing reflects iteration through that deployment. `books-ops` is named here as deployment context, not as a documentation reference; everything load-bearing in this doc is inlined directly so a public reader without `rmorison` access can apply it end-to-end.
+
+---
+
+## See also
+
+- [`ai/claude-code/README.md`](../ai/claude-code/README.md) — canonical six-layer architecture description
+- [ADR-0001](../docs/engineering/adr/0001-six-layer-ai-architecture.md) — the architectural decision
+- [`process/feature-development-workflow.md`](./feature-development-workflow.md) — feature workflow these CE skills operate within
+- [`process/issue-tracking.md`](./issue-tracking.md) — team-scale issue ceremony (compared with the solo + AI mode above)
+- [`process/git-branching-strategy.md`](./git-branching-strategy.md) — branch-naming and review-gate context
+- [Compound-engineering plugin](https://github.com/EveryInc/compound-engineering-plugin) — the canonical Layer 2/3/4/5 realization

--- a/process/documentation-standards.md
+++ b/process/documentation-standards.md
@@ -45,6 +45,8 @@ Repository documentation lives under `docs/` with the following top-level direct
   - Monitoring and alerting setup
   - Infrastructure as code documentation
 
+> **When compound-engineering is in use**: CE-skill outputs add the following paths to the documentation tree — `docs/ideation/`, `docs/brainstorms/`, `docs/plans/` (subsumes `docs/planning/`), `docs/solutions/`. See [`process/compound-engineering-integration.md`](./compound-engineering-integration.md) § 2 for the full path mapping and precedence rule.
+
 ## File Naming Conventions
 
 - Use lowercase kebab-case: `feature-name.md`, `api-design.md`

--- a/process/feature-development-workflow.md
+++ b/process/feature-development-workflow.md
@@ -47,6 +47,8 @@ flowchart LR
 
 **Time**: Hours to days
 
+> **When compound-engineering is in use**: Phase 0 (discovery) is realized by `ce-brainstorm`, which produces `docs/brainstorms/<topic>-requirements.md`. That artifact IS the Phase 0 / discovery output for CE-using projects, and Phase 1 (Product Concept) is seeded from it rather than starting cold. See [`process/compound-engineering-integration.md`](./compound-engineering-integration.md).
+
 **Example**:
 ```markdown
 # Feature Concept: User Notification System

--- a/process/git-branching-strategy.md
+++ b/process/git-branching-strategy.md
@@ -8,6 +8,8 @@ This strategy follows **[GitHub Flow](https://docs.github.com/en/get-started/usi
 
 **Core principle**: `main` branch is always deployable. All work happens in feature branches, merged via pull requests after review.
 
+> **When compound-engineering is in use**: see [`process/compound-engineering-integration.md`](./compound-engineering-integration.md) for branch-naming carve-outs (CE's `lfg`/`ce-work` autonomous flows) and the AI-review discipline that complements branch protection.
+
 ### Workflow Diagram
 
 ```mermaid
@@ -290,6 +292,8 @@ Maintain `CHANGELOG.md` or use [GitHub Releases](https://docs.github.com/en/repo
 
 **Solution**: Create issue first (even for small fixes), use issue-based branching
 
+**Exception**: When compound-engineering is in use, `lfg` and `ce-work` autonomous flows may produce topic-style branches (`feat/...`, `fix/...`) without a parent issue. File an issue retroactively only if review surfaces something worth tracking. See [`process/compound-engineering-integration.md`](./compound-engineering-integration.md).
+
 ### ❌ Stale Branches Not Synced
 
 **Problem**: Merge conflicts, integration problems discovered late
@@ -327,6 +331,8 @@ Configure these rules for `main` branch in repository settings:
 - ✅ Require status checks to pass (CI/tests)
 - ✅ Require branches to be up to date before merging
 - ✅ Delete head branches automatically after merge
+
+**When compound-engineering is in use**: the "Require at least 1 approval" rule has a process-level complement — the AI-review **discipline** (`ce-code-review` + `ce-doc-review`) defined in [`process/compound-engineering-integration.md`](./compound-engineering-integration.md). The discipline is process-level, not enforced by repo configuration; the standards' approval rule re-engages when a human reviewer onboards.
 
 See [GitHub branch protection](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches) for setup details.
 

--- a/process/issue-tracking.md
+++ b/process/issue-tracking.md
@@ -16,6 +16,8 @@
 
 This document defines how to organize issues, track epics, and manage multi-issue initiatives in GitHub. It provides a lightweight, scalable approach using GitHub's native features.
 
+> **When compound-engineering is in use**: solo + AI work often runs at a smaller scale than the three-tier hierarchy below assumes. The standard already carries solo carve-outs at the Epic Size Guidelines section (below) — "<3 issues: probably doesn't need an epic, just use labels", "<1 month: might not need epic structure". For CE-using solo projects, plan files (`docs/plans/...`) serve as the granular tracker via U-IDs, with reactive sub-issues filed for review residuals, bugs, and Open Question activations. See [`process/compound-engineering-integration.md`](./compound-engineering-integration.md) § 3 for the full ticket-policy pattern.
+
 ## Three-Tier Hierarchy
 
 Use a three-tier structure to organize work from high-level initiatives down to specific implementation tasks:

--- a/process/project-planning-standards.md
+++ b/process/project-planning-standards.md
@@ -85,6 +85,8 @@ For team settings, use planning poker:
 
 Individual contributors can estimate solo but should validate assumptions with technical leads.
 
+> **When compound-engineering is in use**: planning poker is N/A for solo + AI work. Point estimates in CE plan files (`docs/plans/...` U-IDs) serve as the self-calibration mechanism — useful for personal pacing rather than team coordination. See [`process/compound-engineering-integration.md`](./compound-engineering-integration.md) § 5.
+
 ## Task Breakdown
 
 ### Decomposition Strategy

--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -16,10 +16,40 @@
 Always read the relevant spec and existing code before making changes.
 Present a plan and wait for confirmation before writing any code.
 
+When [compound-engineering](https://github.com/EveryInc/compound-engineering-plugin)
+is in use, `/ce-plan` produces the plan and `/ce-work` executes it
+iteratively against U-IDs and acceptance criteria; the `lfg` autonomous
+flow runs without per-step confirmation when a complete plan exists.
+See `process/compound-engineering-integration.md`.
+
 ### Standards References
 - Feature workflow: process/feature-development-workflow.md
 - Documentation: process/documentation-standards.md
 - Git conventions: process/git-branching-strategy.md
+- Compound-engineering integration (when CE is installed): process/compound-engineering-integration.md
+
+### AI Architecture
+This template assumes the six-layer AI architecture defined in
+`ai/claude-code/README.md`. The architecture is the abstraction;
+specific toolkits realize the layers:
+
+- **Layers 1 (Rules) and 6 (Hooks)** live in `ai/claude-code/rules/`
+  and `templates/.claude/hooks/` respectively (vendor-neutral; shipped
+  by the standards repo).
+- **Layers 2 (Skills) and 3 (Agents)** have vendor-neutral baselines
+  in `templates/.claude/skills/` and `templates/.claude/agents/`. When
+  compound-engineering is installed, CE skills (`/ce-brainstorm`,
+  `/ce-plan`, `/ce-work`, `/ce-doc-review`, `/ce-code-review`, etc.)
+  and CE persona reviewers are the canonical realization of those
+  layers.
+- **Layers 4 (References) and 5 (Compound)** are realized by CE today;
+  non-CE projects may leave them empty or fill with hand-rolled
+  implementations.
+
+For the architectural decision and full layer descriptions, see
+`docs/engineering/adr/0001-six-layer-ai-architecture.md` and
+`ai/claude-code/README.md` (paths assume the standards repo is
+checked out at the same level; adjust as needed for your project).
 
 ### Module Boundaries
 Each module has a single responsibility. Do not move logic between modules


### PR DESCRIPTION
## What this PR does

Refactors the AI architecture from a 4-layer model (Rules / Skills / Agents / Hooks, established by PRs #16/#19/#21) to a **6-layer model** that better accommodates a developed LLM-engineering system. The architecture is the **abstraction**; **compound-engineering (CE)** is named as the **canonical realization** of Layers 2–5. Vendor-neutral baselines remain in place for projects that don't adopt a specific toolkit; the layering itself preserves vendor-neutrality.

## Architecture

| # | Layer | Principle | Vendor-neutral baseline | CE realization |
|---|-------|-----------|-------------------------|----------------|
| 1 | Rules | Persistence | \`ai/claude-code/rules/\` | (not provided by CE) |
| 2 | Workflow Skills | Composability | \`templates/.claude/skills/\` | \`/ce-brainstorm\`, \`/ce-plan\`, \`/ce-work\`, … |
| 3 | Persona Agents | Perspective | \`templates/.claude/agents/\` | ~20 CE persona reviewers |
| 4 | References | Progressivity | (none yet) | CE skills' \`references/*.md\` |
| 5 | Compound / Learnings | Compounding | (none yet) | \`docs/solutions/\`, \`ce-compound\` |
| 6 | Hooks | Determinism | \`templates/.claude/hooks/\` | (not provided by CE) |

References (Layer 4) and Compound (Layer 5) are first-class layers for the first time. Layer 2 and Layer 3 definitions refined to acknowledge orchestrator-vs-standalone variation. The 4-layer's principle (*\"context is expensive — only load what's needed, when it's needed\"*) is preserved and extended across all six layers.

## Iteration history

The first plan iteration on this issue went through three rounds of multi-persona doc-review under shifting framings (supersede the 4-layer → specialize within it → morph it). That plan is abandoned and preserved as iteration history at \`docs/plans/2026-05-03-001-...-plan.md\`. The active plan at \`docs/plans/2026-05-03-002-...-plan.md\` reflects the architectural redesign decision. Operational findings from the first iteration (books-ops privacy resolved by inlining, AI-review framed as discipline not enforced gate, archive prior proposals to top-level \`archive/\`, etc.) carried forward.

## What's new

- **\`docs/engineering/adr/0001-six-layer-ai-architecture.md\`** — the ADR
- **\`ai/claude-code/README.md\`** — rewritten as canonical 6-layer description (publication-quality framing, readable as standalone architectural description)
- **\`process/compound-engineering-integration.md\`** — operational reference for CE adoption (self-contained; no books-ops links for content)
- **\`archive/\`** — three prior \`ai/*.md\` proposals relocated here as path-not-taken (banners point at the ADR)

## What's updated

- \`ai/CLAUDE.md\` — two-mode framing (standards-mode default + CE-mode addendum)
- \`ai/claude-code/rules/*.md\` — compact CE-aware pointers (Layer 1 stays under 65 lines)
- \`templates/CLAUDE.md\` — adds AI Architecture section + CE-aware Plan Before Implement
- \`README.md\` — 6-row layer table replaces 4-row; integration doc Process Standards entry; CE pointer in For New Projects
- \`process/git-branching-strategy.md\` — anti-pattern carve-out for \`lfg\`/\`ce-work\`; Layer 3 review-discipline note in branch protection
- \`process/feature-development-workflow.md\`, \`process/issue-tracking.md\`, \`process/project-planning-standards.md\`, \`process/documentation-standards.md\` — additive CE cross-refs

## Test plan

Pure documentation refactor. No code changes. Verification by reading.

- [ ] ADR reads as standalone architectural description for a reader without \`rmorison\` context
- [ ] \`ai/claude-code/README.md\` describes 6 layers with vendor-neutral baseline + CE realization columns and the layer-composition diagram
- [ ] Integration doc is self-contained — no books-ops link required to apply it
- [ ] Layer 1 rule files stay compact (under 150 lines each per the architecture's discipline)
- [ ] All cross-refs in process docs are additive (\"when CE is in use...\"), never subtractive
- [ ] Archive banners link correctly from \`archive/<file>.md\` to \`../docs/engineering/adr/0001-...\`

## Notes for review

- **The architectural framing is the central contribution.** Reviewing the ADR and \`ai/claude-code/README.md\` first will help everything else make sense before evaluating individual file diffs.
- **PR size**: ~1,800 lines added across ~17 files, larger than the standards' 200–400 target. The artifacts cross-reference each other (ADR ↔ integration doc ↔ \`ai/CLAUDE.md\` ↔ rules ↔ README ↔ templates), so splitting forces stub artifacts. The cross-reference coherence is the rationale for shipping as one PR.
- **The four-layer model is built on, not superseded.** PRs #16/#19/#21 introduced the original 4-layer; this PR refines it with the patterns CE surfaced.
- **Issue #12** (Phase 0 in feature workflow) is partially addressed — \`docs/brainstorms/\` declared as Phase 0 artifact when CE is in use. Verify #12's acceptance language before closing.

Closes #22 (if accepted as-is).